### PR TITLE
Address integration feedback from FPS CharacterBody3D project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,29 @@ kickback/
 - Collision: layer 4 (active ragdoll), layer 5 (partial ragdoll)
 - Setup tool offers presets: "Active Ragdoll" or "Partial Ragdoll"
 
+## character_root_path architecture
+- `character_root_path` on KickbackCharacter and ActiveRagdollController must point to the gameplay root (the node that represents the character's world position)
+- The setup tool defaults to `..` assuming Kickback nodes are direct children of the character root
+- If Kickback nodes are inside a model sub-scene, override the path to reach the actual gameplay root (e.g., `../../MyCharacter`)
+- Recovery teleports this node to the ragdoll landing position — pointing to the wrong node breaks character positioning
+
+## CharacterBody3D integration
+
+Kickback demos use Node3D roots. If your character uses CharacterBody3D:
+
+- **Stop calling `move_and_slide()`** during RAGDOLL/GETTING_UP/PERSISTENT states — the physics rig drives position
+- **Disable the CharacterBody3D collision shape** during reactions, re-enable after `recovery_finished`
+- **Set `transfer_character_velocity = false`** in RagdollTuning if enemies walk toward threats (prevents ragdoll launching forward)
+- **Use `get_active_state()`** to distinguish states for collision/movement logic:
+  ```gdscript
+  match kickback.get_active_state():
+      ActiveRagdollController.State.RAGDOLL, \
+      ActiveRagdollController.State.GETTING_UP, \
+      ActiveRagdollController.State.PERSISTENT:
+          return  # Ragdoll is driving — skip movement
+  ```
+- **Use `RagdollTuning.create_game_default()`** for amplified reactions suited to fast-paced games
+
 ## Locomotion with active ragdoll
 - **All root movement and rotation MUST happen in `_physics_process`**, not `_process`. The spring resolver runs in `_physics_process` — modifying the root in `_process` causes spring targets to jump.
 - Play animations once on state transitions, not every frame.

--- a/addons/kickback/active_ragdoll_controller.gd
+++ b/addons/kickback/active_ragdoll_controller.gd
@@ -26,7 +26,12 @@ const _MOVEMENT_VELOCITY_THRESHOLD_SQ := 0.25  # (0.5 m/s)^2
 ## Path to the PhysicsRigBuilder that owns the ragdoll RigidBody3D nodes.
 @export var rig_builder_path: NodePath
 ## Path to the character root Node3D for repositioning during get-up recovery.
+## Must point to the gameplay root (e.g., CharacterBody3D or top-level Node3D),
+## NOT a model sub-node. The setup tool defaults to ".." assuming Kickback nodes
+## are direct children of the character root.
 @export var character_root_path: NodePath
+## Path to PhysicsRigSync for forcing skeleton updates after recovery teleport.
+@export var rig_sync_path: NodePath
 
 ## Character state for the active ragdoll lifecycle.
 enum State {
@@ -40,6 +45,7 @@ enum State {
 var _spring: SpringResolver
 var _rig_builder: PhysicsRigBuilder
 var _character_root: Node3D
+var _rig_sync: PhysicsRigSync
 var _adjacency: Dictionary = {}
 var _protected_set: Dictionary = {}  # Cached O(1) lookup for protected bones
 var _state: int = State.NORMAL
@@ -102,6 +108,8 @@ func _ready() -> void:
 	_rig_builder = get_node(rig_builder_path) as PhysicsRigBuilder
 	if not character_root_path.is_empty():
 		_character_root = get_node(character_root_path) as Node3D
+	if not rig_sync_path.is_empty():
+		_rig_sync = get_node(rig_sync_path) as PhysicsRigSync
 	_ensure_config()
 	_build_adjacency()
 	_rebuild_protected_set()
@@ -541,11 +549,12 @@ func _full_ragdoll() -> void:
 		_spring.set_bone_strength(rig_name, 0.0)
 
 	# Transfer character movement velocity to physics bodies
-	var char_velocity := _get_character_velocity()
-	if char_velocity.length_squared() > 0.01:
-		var bodies := _rig_builder.get_bodies()
-		for body: RigidBody3D in bodies.values():
-			body.linear_velocity += char_velocity
+	if _tuning.transfer_character_velocity:
+		var char_velocity := _get_character_velocity() * _tuning.velocity_transfer_scale
+		if char_velocity.length_squared() > 0.01:
+			var bodies := _rig_builder.get_bodies()
+			for body: RigidBody3D in bodies.values():
+				body.linear_velocity += char_velocity
 
 	_state = State.RAGDOLL
 	_ragdoll_elapsed = 0.0
@@ -631,6 +640,10 @@ func _start_recovery() -> void:
 
 	_ragdoll_poses = saved_transforms.duplicate()
 	recovery_started.emit(face_up)
+
+	# Force skeleton sync to prevent 1-frame visual pop after root teleport
+	if _rig_sync:
+		_rig_sync.sync_now()
 
 
 func _finish_recovery() -> void:
@@ -844,6 +857,10 @@ func _sync_injuries_to_resolver() -> void:
 		_spring.set_pin_injury(rig_name, _injuries[rig_name])
 
 
+## Returns the character root's movement velocity for ragdoll momentum transfer.
+## Reads CharacterBody3D.velocity automatically, or calls get_velocity() if present.
+## For CharacterBody3D enemies that walk toward the player, set
+## transfer_character_velocity = false in RagdollTuning to prevent forward-launching.
 func _get_character_velocity() -> Vector3:
 	if not _character_root:
 		return Vector3.ZERO

--- a/addons/kickback/kickback_character.gd
+++ b/addons/kickback/kickback_character.gd
@@ -17,7 +17,10 @@ enum Mode {
 @export var skeleton_path: NodePath
 ## Path to the AnimationPlayer (optional — only needed if using RagdollAnimator).
 @export var animation_player_path: NodePath
-## Path to the character's root Node3D.
+## Path to the character's root Node3D (gameplay root, not model sub-node).
+## This node is teleported during ragdoll recovery. The setup tool defaults to
+## ".." assuming Kickback nodes are direct children of the character root. If
+## nodes are inside a model sub-scene, override to reach the actual gameplay root.
 @export var character_root_path: NodePath
 
 @export_group("Configuration")
@@ -186,6 +189,14 @@ func get_active_state_name() -> String:
 	if _active_controller:
 		return _active_controller.get_state_name()
 	return "N/A"
+
+
+## Returns the active ragdoll state as an [enum ActiveRagdollController.State] int.
+## Returns -1 if no active controller is present.
+func get_active_state() -> int:
+	if _active_controller:
+		return _active_controller.get_state()
+	return -1
 
 
 ## Returns true if the Kickback system has finished initializing.

--- a/addons/kickback/kickback_plugin.gd
+++ b/addons/kickback/kickback_plugin.gd
@@ -229,6 +229,7 @@ func _execute_preset(preset_name: String) -> void:
 		active.set("spring_resolver_path", NodePath("../SpringResolver"))
 		active.set("rig_builder_path", NodePath("../PhysicsRigBuilder"))
 		active.set("character_root_path", NodePath(".."))
+		active.set("rig_sync_path", NodePath("../PhysicsRigSync"))
 		nodes.append(active)
 
 	if include_partial:

--- a/addons/kickback/physics_rig_sync.gd
+++ b/addons/kickback/physics_rig_sync.gd
@@ -40,6 +40,17 @@ func is_active() -> bool:
 	return _active
 
 
+## Forces an immediate skeleton sync outside the normal _process() cycle.
+## Call after teleporting the character root and restoring body transforms
+## to prevent a 1-frame visual pop.
+func sync_now() -> void:
+	if not _active or not _rig_builder or not _skeleton:
+		return
+	if not _cache_built:
+		_build_cache()
+	_do_sync()
+
+
 func _build_cache() -> void:
 	if not _profile:
 		_profile = RagdollProfile.create_mixamo_default()
@@ -70,10 +81,12 @@ func _build_cache() -> void:
 func _process(_delta: float) -> void:
 	if not _active or not _rig_builder or not _skeleton:
 		return
-
 	if not _cache_built:
 		_build_cache()
+	_do_sync()
 
+
+func _do_sync() -> void:
 	var skel_global_inv := _skeleton.global_transform.affine_inverse()
 
 	# Direct sync: body transform IS the bone transform

--- a/addons/kickback/resources/ragdoll_tuning.gd
+++ b/addons/kickback/resources/ragdoll_tuning.gd
@@ -267,6 +267,11 @@ extends Resource
 @export var max_angular_velocity: float = 20.0
 ## Maximum linear velocity for spring-driven bodies.
 @export var max_linear_velocity: float = 10.0
+## Transfer the character's movement velocity to ragdoll bodies on ragdoll entry.
+## Disable for enemies walking toward the player to prevent forward-launching.
+@export var transfer_character_velocity: bool = true
+## Scale factor for velocity transfer (0.0–1.0). Only used when transfer is enabled.
+@export_range(0.0, 1.0) var velocity_transfer_scale: float = 1.0
 ## How long bodies must be below velocity thresholds to count as settled.
 @export var settle_duration: float = 0.6
 ## Linear velocity threshold for settle detection.
@@ -284,7 +289,8 @@ extends Resource
 
 @export_group("Advanced: Ground & Root Motion")
 ## Collision mask for ground raycasts during get-up recovery.
-@export_flags_3d_physics var ground_raycast_mask: int = 2
+## Defaults to layer 1 (world geometry in standard Godot projects).
+@export_flags_3d_physics var ground_raycast_mask: int = 1
 ## Whether to align the character root to the ground slope during recovery.
 @export var align_to_slope: bool = false
 ## Raycast origin offset above the hip position (meters).
@@ -304,6 +310,22 @@ extends Resource
 ## since all property defaults are pre-populated.
 static func create_default() -> RagdollTuning:
 	return RagdollTuning.new()
+
+
+## Creates a RagdollTuning for fast-paced action games with amplified reactions.
+## Increases micro-reaction intensity, sway force, and pain escalation
+## for more visible hit feedback compared to the realistic defaults.
+static func create_game_default() -> RagdollTuning:
+	var t := RagdollTuning.new()
+	t.micro_reaction_strength = 1.2
+	t.micro_head_whip_strength = 3.5
+	t.micro_torso_bend_strength = 2.5
+	t.micro_spin_strength = 2.0
+	t.stagger_sway_strength = 600.0
+	t.reaction_pulse_strength = 0.9
+	t.stagger_duration = 1.2
+	t.pain_gain = 0.35
+	return t
 
 
 ## Validates that all dictionary keys in this tuning reference valid rig names

--- a/test/test_resources.gd
+++ b/test/test_resources.gd
@@ -142,3 +142,17 @@ func test_tuning_validates_clean():
 	var profile := RagdollProfile.create_mixamo_default()
 	var warnings := t.validate_against_profile(profile)
 	assert_eq(warnings.size(), 0, "Default tuning should validate cleanly")
+
+
+func test_game_default_tuning():
+	var t := RagdollTuning.create_game_default()
+	assert_not_null(t)
+	assert_gt(t.micro_reaction_strength, 1.0, "Game preset should amplify micro reactions")
+	assert_gt(t.stagger_sway_strength, 500.0, "Game preset should amplify sway")
+	assert_lt(t.stagger_duration, 1.5, "Game preset should have shorter stagger")
+
+
+func test_tuning_velocity_transfer_defaults():
+	var t := RagdollTuning.create_default()
+	assert_true(t.transfer_character_velocity, "Velocity transfer should default to enabled")
+	assert_eq(t.velocity_transfer_scale, 1.0, "Velocity transfer scale should default to 1.0")


### PR DESCRIPTION
## Summary

Fixes 8 issues discovered during real-world integration into an FPS with CharacterBody3D enemies:

- **Fix 1-frame visual pop during recovery**: Add `PhysicsRigSync.sync_now()` and call it after `_start_recovery()` teleports the character root. Add `rig_sync_path` export to `ActiveRagdollController` (auto-wired by setup tool)
- **Configurable velocity transfer**: Add `transfer_character_velocity` and `velocity_transfer_scale` to `RagdollTuning` — disable for enemies walking toward the player to prevent ragdoll launching forward
- **Fix ground_raycast_mask default**: 2 → 1 (layer 1 = world geometry in standard Godot projects)
- **Granular state API**: Add `KickbackCharacter.get_active_state()` returning raw State enum (distinguishes RAGDOLL vs GETTING_UP vs PERSISTENT)
- **Game tuning preset**: Add `RagdollTuning.create_game_default()` with amplified micro-reactions, sway, and pain escalation
- **Document `character_root_path`**: Must point to gameplay root, not model sub-node
- **Document CharacterBody3D integration**: When to disable collision/move_and_slide, state-driven movement pattern

## Test plan

- [x] Existing tests pass (59 tests + 2 new: `test_game_default_tuning`, `test_tuning_velocity_transfer_defaults`)
- [x] Scenes missing `rig_sync_path` still work (null guard, no crash)
- [x] `transfer_character_velocity = false` prevents velocity transfer on ragdoll entry
- [x] Recovery ground detection hits layer 1 geometry with new default

🤖 Generated with [Claude Code](https://claude.com/claude-code)