### PR TITLE
Fix torso collision shapes: revert to original proportions

### DIFF
--- a/addons/kickback/skeleton_detector.gd
+++ b/addons/kickback/skeleton_detector.gd
@@ -143,10 +143,10 @@ const BONE_CHAINS := {
 ## "capsule" bones: "radius_ratio" and "height_ratio" scale the bone length.
 ## "offset": collision shape offset ratio along the bone direction.
 const BONE_PROPORTIONS := {
-	# Torso: wide, relatively thin front-to-back
-	"Hips":        {"proportions": Vector3(1.8, 1.0, 1.3), "offset": 0.5, "min_size": Vector3(0.30, 0.15, 0.20)},
-	"Spine":       {"proportions": Vector3(1.5, 0.9, 0.9), "offset": 0.5, "min_size": Vector3(0.25, 0.14, 0.14)},
-	"Chest":       {"proportions": Vector3(1.8, 1.1, 1.1), "offset": 0.5, "min_size": Vector3(0.30, 0.18, 0.18)},
+	# Torso: original formula (1.4, 0.8, 1.0) — these were already fine
+	"Hips":        {"proportions": Vector3(1.4, 0.8, 1.0), "offset": 0.5, "min_size": Vector3(0.08, 0.05, 0.08)},
+	"Spine":       {"proportions": Vector3(1.4, 0.8, 1.0), "offset": 0.5, "min_size": Vector3(0.08, 0.05, 0.08)},
+	"Chest":       {"proportions": Vector3(1.4, 0.8, 1.0), "offset": 0.5, "min_size": Vector3(0.08, 0.05, 0.08)},
 	# Hands: flat, longer than wide (palm + fingers extent)
 	"Hand_L":      {"depth_is_length": true, "width_ratio": 0.48, "height_ratio": 0.28, "offset": 0.5, "min_size": Vector3(0.08, 0.03, 0.10)},
 	"Hand_R":      {"depth_is_length": true, "width_ratio": 0.48, "height_ratio": 0.28, "offset": 0.5, "min_size": Vector3(0.08, 0.03, 0.10)},


### PR DESCRIPTION
## Summary
- Reverts Hips, Spine, and Chest `BONE_PROPORTIONS` back to the original `(1.4, 0.8, 1.0)` ratios
- PR #40 incorrectly changed these — only hands and feet needed new proportions

## Test plan
- [x] All 75 GUT tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)