### PR TITLE
Add edit-time validation for profile and tuning

### DIFF
--- a/addons/kickback/editor/kickback_status_panel.gd
+++ b/addons/kickback/editor/kickback_status_panel.gd
@@ -74,6 +74,29 @@ func _build_ui() -> void:
 				bake_btn.pressed.connect(_on_bake.bind(rig_builder))
 			add_child(bake_btn)
 
+	# Validation (#23 + #24)
+	_add_section("Validation")
+	var all_warnings := PackedStringArray()
+
+	var profile: RagdollProfile = _kc.ragdoll_profile if _kc.ragdoll_profile else RagdollProfile.create_mixamo_default()
+	var tuning: RagdollTuning = _kc.ragdoll_tuning if _kc.ragdoll_tuning else RagdollTuning.create_default()
+
+	# Profile vs skeleton (#23)
+	var skeleton := _kc.get_node_or_null(_kc.skeleton_path) as Skeleton3D
+	if skeleton:
+		var profile_warnings := profile.validate_against_skeleton(skeleton)
+		all_warnings.append_array(profile_warnings)
+
+	# Tuning vs profile (#24)
+	var tuning_warnings := tuning.validate_against_profile(profile)
+	all_warnings.append_array(tuning_warnings)
+
+	if all_warnings.is_empty():
+		_add_check("No issues", true)
+	else:
+		for w: String in all_warnings:
+			_add_check(w, false)
+
 	# Tips
 	add_child(HSeparator.new())
 	var tips := Label.new()

--- a/addons/kickback/resources/ragdoll_profile.gd
+++ b/addons/kickback/resources/ragdoll_profile.gd
@@ -114,3 +114,34 @@ static func create_mixamo_default() -> RagdollProfile:
 	profile.intermediate_bones.append(neck)
 
 	return profile
+
+
+## Validates this profile against a Skeleton3D, returning warnings for mismatches.
+func validate_against_skeleton(skeleton: Skeleton3D) -> PackedStringArray:
+	var warnings := PackedStringArray()
+	var rig_names := PackedStringArray()
+
+	for bone_def: BoneDefinition in bones:
+		rig_names.append(bone_def.rig_name)
+		if skeleton.find_bone(bone_def.skeleton_bone) < 0:
+			warnings.append("Bone '%s' maps to '%s' which is not in the skeleton" % [bone_def.rig_name, bone_def.skeleton_bone])
+		if bone_def.child_bone != "" and skeleton.find_bone(bone_def.child_bone) < 0:
+			warnings.append("Bone '%s' child '%s' is not in the skeleton" % [bone_def.rig_name, bone_def.child_bone])
+
+	for joint_def: JointDefinition in joints:
+		if joint_def.parent_rig not in rig_names:
+			warnings.append("Joint parent '%s' is not a defined rig bone" % joint_def.parent_rig)
+		if joint_def.child_rig not in rig_names:
+			warnings.append("Joint child '%s' is not a defined rig bone" % joint_def.child_rig)
+
+	# Foot IK requires specific bones
+	var ik_bones := ["Foot_L", "Foot_R", "UpperLeg_L", "UpperLeg_R", "LowerLeg_L", "LowerLeg_R"]
+	for ik_bone: String in ik_bones:
+		if ik_bone not in rig_names:
+			warnings.append("Foot IK requires '%s' but it is not defined" % ik_bone)
+
+	for entry: IntermediateBoneEntry in intermediate_bones:
+		if skeleton.find_bone(entry.skeleton_bone) < 0:
+			warnings.append("Intermediate bone '%s' is not in the skeleton" % entry.skeleton_bone)
+
+	return warnings


### PR DESCRIPTION
## Summary
- **#23 Profile validation**: New `validate_against_skeleton()` on RagdollProfile — checks bones exist in skeleton, joints reference valid rig names, foot IK bones present, intermediate bones exist
- **#24 Tuning validation**: Existing `validate_against_profile()` now displayed in the inspector alongside profile validation
- Both show in a new **Validation** section in the KickbackCharacter inspector panel — green "No issues" or red warnings per mismatch

## Test plan
- [x] All 76 tests pass
- [x] Default profile + default tuning on Y-Bot → "No issues" (green)
- [x] Edit a profile bone to a bad name → red warning appears
- [x] Add a bad key to strength_map in tuning → red warning appears

Closes #23
Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)