### PR TITLE
Add enhanced status panel and tuning preset dropdown

### DIFF
--- a/addons/kickback/editor/kickback_status_panel.gd
+++ b/addons/kickback/editor/kickback_status_panel.gd
@@ -25,13 +25,27 @@ func _build_ui() -> void:
 	var has_active := _has_sibling_of_type(parent, "ActiveRagdollController") if parent else false
 	var has_partial := _has_sibling_of_type(parent, "PartialRagdollController") if parent else false
 
-	# Mode label
+	# Mode + profile summary
 	var mode_name := "Active Ragdoll" if has_active else ("Partial Ragdoll" if has_partial else "None")
 	var mode_label := Label.new()
 	mode_label.text = "Mode: %s" % mode_name
 	mode_label.add_theme_font_size_override("font_size", 12)
 	mode_label.add_theme_color_override("font_color", Color(0.45, 0.75, 0.45))
 	add_child(mode_label)
+
+	var profile: RagdollProfile = _kc.ragdoll_profile if _kc.ragdoll_profile else RagdollProfile.create_mixamo_default()
+	var tuning: RagdollTuning = _kc.ragdoll_tuning if _kc.ragdoll_tuning else RagdollTuning.create_default()
+
+	# Bone/joint counts
+	var counts_label := Label.new()
+	counts_label.text = "Bones: %d  Joints: %d" % [profile.bones.size(), profile.joints.size()]
+	counts_label.add_theme_font_size_override("font_size", 11)
+	counts_label.add_theme_color_override("font_color", Color(0.6, 0.6, 0.6))
+	add_child(counts_label)
+
+	# Foot IK status
+	var ik_enabled: bool = tuning.foot_ik_enabled
+	_add_check("Foot IK: %s" % ("Enabled" if ik_enabled else "Disabled"), ik_enabled)
 
 	# Setup validation
 	_add_section("Setup")
@@ -74,14 +88,10 @@ func _build_ui() -> void:
 				bake_btn.pressed.connect(_on_bake.bind(rig_builder))
 			add_child(bake_btn)
 
-	# Validation (#23 + #24)
+	# Validation
 	_add_section("Validation")
 	var all_warnings := PackedStringArray()
 
-	var profile: RagdollProfile = _kc.ragdoll_profile if _kc.ragdoll_profile else RagdollProfile.create_mixamo_default()
-	var tuning: RagdollTuning = _kc.ragdoll_tuning if _kc.ragdoll_tuning else RagdollTuning.create_default()
-
-	# Profile vs skeleton (#23)
 	var skeleton := _kc.get_node_or_null(_kc.skeleton_path) as Skeleton3D
 	if skeleton:
 		var profile_warnings := profile.validate_against_skeleton(skeleton)
@@ -96,6 +106,20 @@ func _build_ui() -> void:
 	else:
 		for w: String in all_warnings:
 			_add_check(w, false)
+
+	# Tuning Presets (#30)
+	_add_section("Tuning Presets")
+	var preset_hbox := HBoxContainer.new()
+	var preset_option := OptionButton.new()
+	for preset_name: String in ["Default", "Game", "Tank", "Agile", "Fragile"]:
+		preset_option.add_item(preset_name)
+	preset_option.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	preset_hbox.add_child(preset_option)
+	var apply_btn := Button.new()
+	apply_btn.text = "Apply"
+	apply_btn.pressed.connect(_on_apply_preset.bind(preset_option))
+	preset_hbox.add_child(apply_btn)
+	add_child(preset_hbox)
 
 	# Tips
 	add_child(HSeparator.new())
@@ -126,6 +150,34 @@ func _on_bake(rig_builder: PhysicsRigBuilder) -> void:
 		return
 	var scene_owner: Node = rig_builder.owner if rig_builder.owner else rig_builder
 	RigBaker.bake(rig_builder, _editor_plugin.get_undo_redo(), scene_owner)
+	_refresh()
+
+
+func _on_apply_preset(option: OptionButton) -> void:
+	var preset_name: String = option.get_item_text(option.selected)
+	var new_tuning: RagdollTuning
+	match preset_name:
+		"Default":
+			new_tuning = RagdollTuning.create_default()
+		"Game":
+			new_tuning = RagdollTuning.create_game_default()
+		"Tank":
+			new_tuning = RagdollTuning.create_tank()
+		"Agile":
+			new_tuning = RagdollTuning.create_agile()
+		"Fragile":
+			new_tuning = RagdollTuning.create_fragile()
+		_:
+			new_tuning = RagdollTuning.create_default()
+
+	if _editor_plugin:
+		var undo := _editor_plugin.get_undo_redo()
+		undo.create_action("Apply Kickback Tuning Preset: %s" % preset_name)
+		undo.add_do_property(_kc, "ragdoll_tuning", new_tuning)
+		undo.add_undo_property(_kc, "ragdoll_tuning", _kc.ragdoll_tuning)
+		undo.commit_action()
+	else:
+		_kc.ragdoll_tuning = new_tuning
 	_refresh()
 
 

--- a/addons/kickback/resources/ragdoll_tuning.gd
+++ b/addons/kickback/resources/ragdoll_tuning.gd
@@ -375,6 +375,48 @@ static func create_game_default() -> RagdollTuning:
 	return t
 
 
+## Creates a RagdollTuning for tough characters that resist stagger and recover fast.
+static func create_tank() -> RagdollTuning:
+	var t := RagdollTuning.new()
+	t.strength_map = {
+		"Hips": 0.90, "Spine": 0.85, "Chest": 0.85, "Head": 0.70,
+		"UpperArm_L": 0.75, "LowerArm_L": 0.65, "Hand_L": 0.50,
+		"UpperArm_R": 0.75, "LowerArm_R": 0.65, "Hand_R": 0.50,
+		"UpperLeg_L": 0.80, "LowerLeg_L": 0.70, "Foot_L": 0.55,
+		"UpperLeg_R": 0.80, "LowerLeg_R": 0.70, "Foot_R": 0.55,
+	}
+	t.pin_strength_overrides = {"Hips": 0.95, "Foot_L": 0.6, "Foot_R": 0.6}
+	t.default_pin_strength = 0.3
+	t.recovery_rate = 0.8
+	t.stagger_threshold = 0.3
+	t.stagger_strength_floor = 0.50
+	t.stagger_duration = 0.3
+	return t
+
+
+## Creates a RagdollTuning for nimble characters that stagger easily but recover fast.
+static func create_agile() -> RagdollTuning:
+	var t := RagdollTuning.new()
+	t.stagger_threshold = 0.80
+	t.stagger_duration = 1.0
+	t.recovery_rate = 0.5
+	t.fatigue_decay = 0.15
+	t.pain_decay = 0.25
+	return t
+
+
+## Creates a RagdollTuning for characters that ragdoll easily under sustained fire.
+static func create_fragile() -> RagdollTuning:
+	var t := RagdollTuning.new()
+	t.stagger_threshold = 0.80
+	t.stagger_strength_floor = 0.10
+	t.stagger_duration = 0.8
+	t.stagger_ragdoll_bonus = 3.0
+	t.pain_gain = 0.4
+	t.injury_gain = 0.3
+	return t
+
+
 ## Validates that all dictionary keys in this tuning reference valid rig names
 ## defined in the given [param profile]. Returns an array of warning strings.
 ## An empty array means all keys are valid.


### PR DESCRIPTION
## Summary
- **#29 Enhanced status panel**: Shows bone/joint counts and foot IK status alongside existing mode, setup, controllers, physics rig, and validation sections
- **#30 Tuning presets**: Dropdown with 5 presets (Default, Game, Tank, Agile, Fragile) + Apply button. Creates new RagdollTuning via factory methods with undo/redo support
- New factory methods on RagdollTuning: `create_tank()`, `create_agile()`, `create_fragile()`

## Test plan
- [x] All 76 tests pass
- [ ] Inspector shows bone/joint counts and foot IK status
- [ ] Select "Tank" preset → Apply → character gets stiff springs, hard to stagger
- [ ] Ctrl+Z undoes preset change

Closes #29
Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)