### PR TITLE
Add joint compliance and per-state collision control

### DIFF
--- a/addons/kickback/active_ragdoll_controller.gd
+++ b/addons/kickback/active_ragdoll_controller.gd
@@ -48,6 +48,7 @@ var _character_root: Node3D
 var _rig_sync: PhysicsRigSync
 var _adjacency: Dictionary = {}
 var _protected_set: Dictionary = {}  # Cached O(1) lookup for protected bones
+var _disabled_collision_masks: Dictionary = {}  # rig_name → original collision_mask
 var _state: int = State.NORMAL
 var _recovery_elapsed: float = 0.0
 var _ragdoll_elapsed: float = 0.0
@@ -133,6 +134,35 @@ func _rebuild_protected_set() -> void:
 ## Re-caches values that are stored at init time. Call when tuning changes at runtime.
 func refresh_tuning() -> void:
 	_rebuild_protected_set()
+
+
+## Disables collision_mask for bones listed in normal_state_disabled_collision.
+## Call when entering NORMAL state. Caches original masks for restoration.
+func _disable_normal_collisions() -> void:
+	if not _tuning or _tuning.normal_state_disabled_collision.is_empty():
+		return
+	if not _spring:
+		return
+	var bodies: Dictionary = _rig_builder.get_bodies() if _rig_builder else {}
+	for rig_name: String in _tuning.normal_state_disabled_collision:
+		if rig_name in bodies:
+			var body: RigidBody3D = bodies[rig_name]
+			if rig_name not in _disabled_collision_masks:
+				_disabled_collision_masks[rig_name] = body.collision_mask
+			body.collision_mask = 0
+
+
+## Restores collision_mask for bones disabled by _disable_normal_collisions().
+## Call when entering STAGGER or RAGDOLL state.
+func _restore_disabled_collisions() -> void:
+	if _disabled_collision_masks.is_empty():
+		return
+	var bodies: Dictionary = _rig_builder.get_bodies() if _rig_builder else {}
+	for rig_name: String in _disabled_collision_masks:
+		if rig_name in bodies:
+			var body: RigidBody3D = bodies[rig_name]
+			body.collision_mask = _disabled_collision_masks[rig_name]
+	_disabled_collision_masks.clear()
 
 
 func _build_adjacency() -> void:
@@ -569,6 +599,7 @@ func get_state_name() -> String:
 # ── State Transitions ───────────────────────────────────────────────────────
 
 func _full_ragdoll() -> void:
+	_restore_disabled_collisions()
 	for rig_name: String in _spring.get_all_bone_names():
 		_spring.set_bone_strength(rig_name, 0.0)
 
@@ -676,6 +707,7 @@ func _finish_recovery() -> void:
 	_spring.recovery_rate = _spring.get_default_recovery_rate()
 	_spring.clear_target_overrides()
 	_ragdoll_poses.clear()
+	_disable_normal_collisions()
 	state_changed.emit(_state)
 
 	for rig_name: String in _spring.get_all_bone_names():
@@ -685,6 +717,7 @@ func _finish_recovery() -> void:
 
 
 func _start_stagger(hit_dir: Vector3) -> void:
+	_restore_disabled_collisions()
 	_state = State.STAGGER
 	_stagger_elapsed = 0.0
 	_balance_stable_timer = 0.0
@@ -720,6 +753,7 @@ func _finish_stagger() -> void:
 	_balance_stable_timer = 0.0
 	_com_initialized = false
 	_spring.recovery_rate = _spring.get_default_recovery_rate()
+	_disable_normal_collisions()
 	state_changed.emit(_state)
 	stagger_finished.emit()
 

--- a/addons/kickback/editor/rig_baker.gd
+++ b/addons/kickback/editor/rig_baker.gd
@@ -113,6 +113,13 @@ static func bake(rig_builder: PhysicsRigBuilder, undo_redo: EditorUndoRedoManage
 		joint.set_param_z(Generic6DOFJoint3D.PARAM_ANGULAR_LOWER_LIMIT, deg_to_rad(joint_def.limit_z.x))
 		joint.set_param_z(Generic6DOFJoint3D.PARAM_ANGULAR_UPPER_LIMIT, deg_to_rad(joint_def.limit_z.y))
 
+		# Joint compliance
+		if joint_def.angular_softness > 0.0 or joint_def.angular_damping > 0.0 or joint_def.angular_restitution > 0.0:
+			for axis in ["x", "y", "z"]:
+				joint.call("set_param_" + axis, Generic6DOFJoint3D.PARAM_ANGULAR_LIMIT_SOFTNESS, joint_def.angular_softness)
+				joint.call("set_param_" + axis, Generic6DOFJoint3D.PARAM_ANGULAR_DAMPING, joint_def.angular_damping)
+				joint.call("set_param_" + axis, Generic6DOFJoint3D.PARAM_ANGULAR_RESTITUTION, joint_def.angular_restitution)
+
 		undo_redo.add_do_method(rig_builder, "add_child", joint)
 		undo_redo.add_do_method(joint, "set_owner", scene_owner)
 		undo_redo.add_do_method(joint, "set", "global_transform", joint_global)

--- a/addons/kickback/physics_rig_builder.gd
+++ b/addons/kickback/physics_rig_builder.gd
@@ -164,6 +164,13 @@ func _create_joint(joint_def: JointDefinition) -> void:
 	joint.set_param_z(Generic6DOFJoint3D.PARAM_ANGULAR_LOWER_LIMIT, deg_to_rad(joint_def.limit_z.x))
 	joint.set_param_z(Generic6DOFJoint3D.PARAM_ANGULAR_UPPER_LIMIT, deg_to_rad(joint_def.limit_z.y))
 
+	# Joint compliance (softness, damping, restitution)
+	if joint_def.angular_softness > 0.0 or joint_def.angular_damping > 0.0 or joint_def.angular_restitution > 0.0:
+		for axis in ["x", "y", "z"]:
+			joint.call("set_param_" + axis, Generic6DOFJoint3D.PARAM_ANGULAR_LIMIT_SOFTNESS, joint_def.angular_softness)
+			joint.call("set_param_" + axis, Generic6DOFJoint3D.PARAM_ANGULAR_DAMPING, joint_def.angular_damping)
+			joint.call("set_param_" + axis, Generic6DOFJoint3D.PARAM_ANGULAR_RESTITUTION, joint_def.angular_restitution)
+
 
 ## Enables the physics rig. On first enable, snaps bodies to skeleton and unfreezes
 ## them permanently. Subsequent calls are no-ops — bodies stay always-simulated

--- a/addons/kickback/resources/joint_definition.gd
+++ b/addons/kickback/resources/joint_definition.gd
@@ -15,3 +15,11 @@ extends Resource
 @export var limit_y: Vector2 = Vector2(-15, 15)
 ## Z-axis angular limit: (lower, upper) in degrees.
 @export var limit_z: Vector2 = Vector2(-10, 10)
+
+@export_group("Compliance")
+## How soft the angular limit boundaries are. 0 = hard stop, 1 = fully soft.
+@export_range(0.0, 1.0) var angular_softness: float = 0.0
+## Damping applied when approaching angular limits. Higher = more resistance.
+@export_range(0.0, 10.0) var angular_damping: float = 0.0
+## Bounciness at angular limit boundaries. 0 = no bounce, 1 = full bounce.
+@export_range(0.0, 1.0) var angular_restitution: float = 0.0

--- a/addons/kickback/resources/ragdoll_tuning.gd
+++ b/addons/kickback/resources/ragdoll_tuning.gd
@@ -200,6 +200,9 @@ extends Resource
 @export_flags_3d_physics var collision_layer: int = 8
 ## Physics collision mask for ragdoll bodies.
 @export_flags_3d_physics var collision_mask: int = 14
+## Bones whose collision_mask is set to 0 during NORMAL state and restored on
+## STAGGER/RAGDOLL. Prevents clipping from animation poses (crossed arms, etc.).
+@export var normal_state_disabled_collision: PackedStringArray = []
 
 # ── Advanced: Spring Dynamics ───────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- **#26 Joint compliance**: `angular_softness`, `angular_damping`, `angular_restitution` on JointDefinition. Default 0 = current hard-stop behavior. Stiff knees vs floppy arms. Applied in PhysicsRigBuilder and RigBaker.
- **#31 Per-state collision**: `normal_state_disabled_collision` on RagdollTuning. Listed bones get `collision_mask=0` in NORMAL state, restored on STAGGER/RAGDOLL. Generalizes the foot IK collision disable for any bone.

## Test plan
- [x] All 76 tests pass
- [x] Set angular_softness=0.5 on an arm joint → softer feel at limits
- [x] Add "Hand_L" to normal_state_disabled_collision → hand doesn't collide in NORMAL

Closes #26
Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)