### PR TITLE
Fix 7 integration friction issues (#51-#57)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ kickback/
 │       ├── spring_resolver.gd       # Velocity-based spring pose matching
 │       ├── active_ragdoll_controller.gd  # State machine (NORMAL/STAGGER/RAGDOLL/GETTING_UP/PERSISTENT)
 │       ├── partial_ragdoll_controller.gd # Standalone selective bone simulation
+│       ├── physics_collision_monitor.gd # Optional ragdoll-environment collision observer
 │       ├── hit_event.gd             # Hit data object
 │       ├── jolt_check.gd            # Jolt physics verification
 │       ├── strength_debug_hud.gd    # F3 debug gizmos (auto-discovers all characters)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,8 @@ kickback/
 ├── docs/
 │   ├── STEP_BY_STEP.md              # Implementation history
 │   ├── GODOT_CONSTRAINTS.md         # Engine quirks and workarounds
-│   └── REFERENCE.md                 # Technical reference: math, profiles, bone mapping
+│   ├── REFERENCE.md                 # Technical reference: math, profiles, bone mapping
+│   └── INTEGRATION.md              # Integration guide: timing, layers, state machine, scoring
 ├── addons/
 │   └── kickback/                    # The plugin (distributable)
 │       ├── plugin.cfg

--- a/addons/kickback/active_ragdoll_controller.gd
+++ b/addons/kickback/active_ragdoll_controller.gd
@@ -66,6 +66,8 @@ var _prev_com: Vector3 = Vector3.ZERO
 var _com_velocity: Vector3 = Vector3.ZERO
 var _com_initialized: bool = false
 var _sway_phase: float = 0.0
+var _hit_guard_frame: int = -1
+var _hit_guard_bodies: Dictionary = {}
 var _profile: RagdollProfile
 var _tuning: RagdollTuning
 var _foot_ik: FootIKSolver
@@ -362,6 +364,17 @@ func apply_hit(body: RigidBody3D, hit_dir: Vector3, hit_pos: Vector3, profile: I
 	if not _tuning or not _spring:
 		push_warning("ActiveRagdollController: apply_hit() called before configure()")
 		return
+
+	# Per-frame debounce: ignore duplicate hits on the same body within a single
+	# physics frame. Prevents feedback loops when body_entered re-triggers hits.
+	var frame := Engine.get_physics_frames()
+	if frame != _hit_guard_frame:
+		_hit_guard_frame = frame
+		_hit_guard_bodies.clear()
+	var body_rid := body.get_rid()
+	if body_rid in _hit_guard_bodies:
+		return
+	_hit_guard_bodies[body_rid] = true
 
 	# Hit streak: rapid consecutive hits escalate
 	var now := Time.get_ticks_msec() / 1000.0

--- a/addons/kickback/kickback_character.gd
+++ b/addons/kickback/kickback_character.gd
@@ -30,6 +30,9 @@ enum Mode {
 ## Physics tuning (spring strengths, recovery, collision layers).
 ## If null, uses built-in defaults.
 @export var ragdoll_tuning: RagdollTuning
+## State to enter automatically after setup completes. "Normal" does nothing.
+## "Ragdoll" triggers an immediate ragdoll. "Persistent" enters persistent ragdoll.
+@export_enum("Normal", "Ragdoll", "Persistent") var initial_state: String = "Normal"
 
 var _skeleton: Skeleton3D
 var _anim_player: AnimationPlayer
@@ -126,6 +129,15 @@ func _ready() -> void:
 		return
 	_ready_complete = true
 	setup_complete.emit()
+
+	# Apply initial state (after setup_complete so listeners can connect first)
+	match initial_state:
+		"Ragdoll":
+			if _active_controller:
+				_active_controller.trigger_ragdoll()
+		"Persistent":
+			if _active_controller:
+				_active_controller.set_persistent(true)
 
 
 func _exit_tree() -> void:
@@ -226,6 +238,28 @@ func trigger_ragdoll() -> void:
 		push_warning("KickbackCharacter: no ActiveRagdollController available for trigger_ragdoll()")
 
 
+## Triggers ragdoll as soon as setup completes. Safe to call at spawn time
+## before the physics rig is built. If setup has already completed, triggers
+## immediately.
+func queue_ragdoll() -> void:
+	if _ready_complete:
+		trigger_ragdoll()
+		return
+	if not setup_complete.is_connected(_deferred_ragdoll):
+		setup_complete.connect(_deferred_ragdoll, CONNECT_ONE_SHOT)
+
+
+## Enables persistent ragdoll as soon as setup completes. Safe to call at
+## spawn time before the physics rig is built. If setup has already completed,
+## enables immediately.
+func queue_persistent() -> void:
+	if _ready_complete:
+		set_persistent(true)
+		return
+	if not setup_complete.is_connected(_deferred_persistent):
+		setup_complete.connect(_deferred_persistent, CONNECT_ONE_SHOT)
+
+
 ## Enables or disables persistent ragdoll (death/knockdown).
 func set_persistent(enabled: bool) -> void:
 	if _active_controller:
@@ -251,6 +285,14 @@ static func _find_all_recursive(node: Node, result: Array[KickbackCharacter]) ->
 		result.append(node)
 	for child in node.get_children():
 		_find_all_recursive(child, result)
+
+
+func _deferred_ragdoll() -> void:
+	trigger_ragdoll()
+
+
+func _deferred_persistent() -> void:
+	set_persistent(true)
 
 
 func _on_tuning_changed() -> void:

--- a/addons/kickback/kickback_character.gd
+++ b/addons/kickback/kickback_character.gd
@@ -44,6 +44,7 @@ var _partial_controller: PartialRagdollController
 
 var _mode: int = Mode.NONE
 var _ready_complete: bool = false
+var _exiting: bool = false
 
 ## Emitted when all controllers are initialized and the character is ready for use.
 signal setup_complete()
@@ -105,11 +106,10 @@ func _ready() -> void:
 
 	_validate_setup()
 
-	await get_tree().process_frame
-	await get_tree().process_frame
-	await get_tree().process_frame
-	await get_tree().process_frame
-	await get_tree().process_frame
+	for i in 5:
+		await get_tree().process_frame
+		if _exiting:
+			return
 
 	# Enable the chosen mode
 	if _mode == Mode.ACTIVE:
@@ -122,8 +122,14 @@ func _ready() -> void:
 	elif _mode == Mode.PARTIAL:
 		_simulator.active = true
 
+	if not is_inside_tree():
+		return
 	_ready_complete = true
 	setup_complete.emit()
+
+
+func _exit_tree() -> void:
+	_exiting = true
 
 
 ## Routes an incoming hit to the active controller.

--- a/addons/kickback/physics_collision_monitor.gd
+++ b/addons/kickback/physics_collision_monitor.gd
@@ -1,0 +1,128 @@
+## Monitors physics contacts on ragdoll bodies and emits impact events.
+## Optional component — add as a sibling to KickbackCharacter. Does NOT
+## trigger hit reactions; emits its own signal for scoring, VFX, and sound.
+##
+## This is completely separate from [method KickbackCharacter.receive_hit].
+## Routing [signal body_impact] back through receive_hit() will cause a
+## feedback loop — use it only for passive observation (damage numbers,
+## particle spawning, audio cues, score tracking).
+@icon("res://addons/kickback/icons/physics_rig_builder.svg")
+class_name PhysicsCollisionMonitor
+extends Node
+
+@export_group("References")
+## Path to the KickbackCharacter sibling. If empty, auto-discovers from siblings.
+@export var kickback_character_path: NodePath
+
+@export_group("Filtering")
+## Minimum impact velocity (m/s) to emit a signal. Contacts below this
+## are silently discarded. Prevents spam from gentle resting contacts.
+@export_range(0.0, 20.0) var velocity_threshold: float = 2.0
+## Per-bone cooldown in seconds. After emitting for a bone, that bone
+## is silenced for this duration.
+@export_range(0.0, 5.0) var cooldown: float = 0.3
+## Which bones to monitor. Empty array = monitor ALL bones.
+@export var monitored_bones: PackedStringArray = []
+## Filter out contacts between bones of the same ragdoll rig.
+@export var filter_self_collisions: bool = true
+
+## Emitted when a monitored ragdoll body impacts the environment.
+## [param bone_name] is the rig name (e.g., "Head", "Foot_L").
+## [param velocity] is the impact speed in m/s at the moment of contact.
+## [param contact_body] is the Node3D that was contacted (e.g., a StaticBody3D).
+signal body_impact(bone_name: String, velocity: float, contact_body: Node3D)
+
+var _kickback_char: KickbackCharacter
+var _rig_builder: PhysicsRigBuilder
+var _connected: bool = false
+var _body_to_rig_name: Dictionary = {}       # RigidBody3D → rig_name
+var _cooldown_timestamps: Dictionary = {}    # rig_name → last emit time (msec)
+var _ragdoll_layer_mask: int = 0
+
+
+func _ready() -> void:
+	if not kickback_character_path.is_empty():
+		_kickback_char = get_node_or_null(kickback_character_path) as KickbackCharacter
+	else:
+		for sibling in get_parent().get_children():
+			if sibling is KickbackCharacter:
+				_kickback_char = sibling
+				break
+
+	if not _kickback_char:
+		push_warning("PhysicsCollisionMonitor: no KickbackCharacter found — monitor disabled")
+		return
+
+	if _kickback_char.is_setup_complete():
+		_connect_to_bodies()
+	else:
+		_kickback_char.setup_complete.connect(_connect_to_bodies, CONNECT_ONE_SHOT)
+
+
+func _connect_to_bodies() -> void:
+	for sibling in get_parent().get_children():
+		if sibling is PhysicsRigBuilder:
+			_rig_builder = sibling
+			break
+
+	if not _rig_builder:
+		push_warning("PhysicsCollisionMonitor: no PhysicsRigBuilder found — monitor disabled")
+		return
+
+	var bodies: Dictionary = _rig_builder.get_bodies()
+	if bodies.is_empty():
+		push_warning("PhysicsCollisionMonitor: PhysicsRigBuilder has no bodies — monitor disabled")
+		return
+
+	_ragdoll_layer_mask = _rig_builder.get_tuning().collision_layer
+
+	var monitor_set: Dictionary = {}
+	for bone_name: String in monitored_bones:
+		monitor_set[bone_name] = true
+
+	for rig_name: String in bodies:
+		if not monitor_set.is_empty() and rig_name not in monitor_set:
+			continue
+
+		var body: RigidBody3D = bodies[rig_name]
+		body.contact_monitor = true
+		body.max_contacts_reported = maxf(body.max_contacts_reported, 1)
+		_body_to_rig_name[body] = rig_name
+		body.body_entered.connect(_on_body_entered.bind(body))
+
+	_connected = true
+
+
+func _on_body_entered(other_body: Node3D, this_body: RigidBody3D) -> void:
+	var rig_name: String = _body_to_rig_name.get(this_body, "")
+	if rig_name.is_empty():
+		return
+
+	# Filter self-collisions (bone-on-bone from the same rig)
+	if filter_self_collisions and other_body is RigidBody3D:
+		if other_body.collision_layer & _ragdoll_layer_mask:
+			if other_body in _body_to_rig_name:
+				return
+
+	# Filter by velocity threshold
+	var speed: float = this_body.linear_velocity.length()
+	if speed < velocity_threshold:
+		return
+
+	# Filter by cooldown
+	var now: float = Time.get_ticks_msec()
+	var last_time: float = _cooldown_timestamps.get(rig_name, 0.0)
+	if (now - last_time) < cooldown * 1000.0:
+		return
+	_cooldown_timestamps[rig_name] = now
+
+	body_impact.emit(rig_name, speed, other_body)
+
+
+func _exit_tree() -> void:
+	if not _connected:
+		return
+	for body: RigidBody3D in _body_to_rig_name.keys():
+		if is_instance_valid(body):
+			body.contact_monitor = false
+			body.max_contacts_reported = 0

--- a/addons/kickback/physics_rig_builder.gd
+++ b/addons/kickback/physics_rig_builder.gd
@@ -15,6 +15,10 @@ var _built: bool = false
 var _profile: RagdollProfile
 var _tuning: RagdollTuning
 
+## Emitted when all ragdoll bodies and joints have been created.
+## After this signal, [method get_bodies] returns the full rig dictionary.
+signal bodies_built()
+
 
 func configure(profile: RagdollProfile, tuning: RagdollTuning) -> void:
 	_profile = profile
@@ -26,6 +30,7 @@ func _ready() -> void:
 	await get_tree().process_frame
 	await get_tree().process_frame
 	_build_rig()
+	bodies_built.emit()
 	set_enabled(false)
 
 
@@ -200,6 +205,13 @@ func snap_to_skeleton() -> void:
 
 
 func get_bodies() -> Dictionary:
+	return _bodies
+
+
+## Returns the bodies dictionary, waiting for the rig to be built if needed.
+func await_bodies() -> Dictionary:
+	if not _built:
+		await bodies_built
 	return _bodies
 
 

--- a/addons/kickback/resources/ragdoll_tuning.gd
+++ b/addons/kickback/resources/ragdoll_tuning.gd
@@ -199,7 +199,7 @@ extends Resource
 ## Physics collision layer for ragdoll bodies.
 @export_flags_3d_physics var collision_layer: int = 8
 ## Physics collision mask for ragdoll bodies.
-@export_flags_3d_physics var collision_mask: int = 14
+@export_flags_3d_physics var collision_mask: int = 15
 ## Bones whose collision_mask is set to 0 during NORMAL state and restored on
 ## STAGGER/RAGDOLL. Prevents clipping from animation poses (crossed arms, etc.).
 @export var normal_state_disabled_collision: PackedStringArray = []

--- a/addons/kickback/resources/ragdoll_tuning.gd
+++ b/addons/kickback/resources/ragdoll_tuning.gd
@@ -420,6 +420,42 @@ static func create_fragile() -> RagdollTuning:
 	return t
 
 
+## Creates a RagdollTuning for responsive action games. Low stagger duration,
+## fast recovery, exaggerated micro-reactions for snappy hit feedback.
+static func create_responsive() -> RagdollTuning:
+	var t := RagdollTuning.new()
+	t.stagger_duration = 0.4
+	t.recovery_rate = 1.0
+	t.stagger_recovery_rate = 0.08
+	t.micro_reaction_strength = 1.5
+	t.micro_head_whip_strength = 4.0
+	t.micro_torso_bend_strength = 3.0
+	t.pain_decay = 0.3
+	t.fatigue_decay = 0.2
+	return t
+
+
+## Creates a RagdollTuning for heavy, weighty characters. High damping,
+## slow recovery, and subdued micro-reactions for a realistic mass feel.
+static func create_heavy() -> RagdollTuning:
+	var t := RagdollTuning.new()
+	t.strength_map = {
+		"Hips": 0.80, "Spine": 0.75, "Chest": 0.75, "Head": 0.50,
+		"UpperArm_L": 0.55, "LowerArm_L": 0.40, "Hand_L": 0.30,
+		"UpperArm_R": 0.55, "LowerArm_R": 0.40, "Hand_R": 0.30,
+		"UpperLeg_L": 0.70, "LowerLeg_L": 0.55, "Foot_L": 0.40,
+		"UpperLeg_R": 0.70, "LowerLeg_R": 0.55, "Foot_R": 0.40,
+	}
+	t.stagger_duration = 2.0
+	t.recovery_rate = 0.2
+	t.gravity_scale = 1.2
+	t.angular_damp = 4.0
+	t.linear_damp = 1.5
+	t.stagger_sway_strength = 300.0
+	t.micro_reaction_strength = 0.5
+	return t
+
+
 ## Validates that all dictionary keys in this tuning reference valid rig names
 ## defined in the given [param profile]. Returns an array of warning strings.
 ## An empty array means all keys are valid.

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -1,0 +1,269 @@
+# Integration Guide
+
+Practical guide for integrating Kickback into a game project. Covers the
+timing contracts, collision setup, state machine, and common patterns that
+aren't obvious from the API reference alone.
+
+---
+
+## Setup Timing
+
+KickbackCharacter defers initialization across multiple frames to let Godot
+finish scene instantiation. Understanding this timing is essential.
+
+### Timeline
+
+```
+Frame 0   KickbackCharacter._ready() starts
+          ├── configure() called on all controllers
+          ├── PhysicsRigBuilder._ready() starts (awaits 2 frames)
+          └── begins 5-frame await
+
+Frame 2   PhysicsRigBuilder._build_rig() runs
+          ├── RigidBody3D nodes created
+          ├── bodies_built signal emitted
+          └── set_enabled(false) freezes bodies
+
+Frame 5   KickbackCharacter finishes await
+          ├── set_enabled(true) unfreezes bodies
+          ├── setup_complete signal emitted
+          └── initial_state applied (if set)
+```
+
+### When is it safe to call APIs?
+
+| API                         | Safe after             |
+|-----------------------------|------------------------|
+| `get_bodies()`              | `bodies_built` signal  |
+| `trigger_ragdoll()`         | `setup_complete` signal|
+| `receive_hit()`             | `setup_complete` signal|
+| `get_active_state()`        | Immediately            |
+| `is_setup_complete()`       | Immediately            |
+
+### Spawning ragdolled characters
+
+Three options, from simplest to most flexible:
+
+**Inspector export** — set `initial_state` to "Ragdoll" or "Persistent":
+```gdscript
+# In the scene tree, set KickbackCharacter.initial_state = "Ragdoll"
+# The character will ragdoll automatically after setup completes.
+```
+
+**queue_ragdoll()** — safe to call immediately after instantiation:
+```gdscript
+var character = preload("res://enemy.tscn").instantiate()
+add_child(character)
+character.get_node("KickbackCharacter").queue_ragdoll()
+# No need to wait for setup — it will ragdoll when ready.
+```
+
+**queue_persistent()** — same pattern for death/knockdown:
+```gdscript
+kickback_char.queue_persistent()
+```
+
+### Configuring bodies after spawn
+
+Use `await_bodies()` on PhysicsRigBuilder to wait for bodies to exist:
+```gdscript
+var bodies: Dictionary = await rig_builder.await_bodies()
+for body: RigidBody3D in bodies.values():
+    body.contact_monitor = true
+    body.max_contacts_reported = 4
+```
+
+Or connect to `bodies_built`:
+```gdscript
+rig_builder.bodies_built.connect(func():
+    var bodies = rig_builder.get_bodies()
+    # configure bodies here
+)
+```
+
+---
+
+## Physics Layers
+
+### Defaults
+
+| Property         | Value | Meaning                              |
+|------------------|-------|--------------------------------------|
+| `collision_layer`| 8     | Layer 4 — ragdoll bodies live here   |
+| `collision_mask` | 15    | Layers 1,2,3,4 — what bodies collide with |
+
+### Layer 1 (environment)
+
+Layer 1 is Godot's default collision layer for all physics bodies. Kickback's
+default mask includes layer 1, so ragdoll bodies collide with standard
+environment geometry out of the box.
+
+If your environment uses a non-default layer, update `RagdollTuning.collision_mask`
+to include it.
+
+### Recommended layer assignment
+
+| Layer | Purpose              |
+|-------|----------------------|
+| 1     | Environment (floors, walls, static geometry) |
+| 2     | Projectiles / raycasts |
+| 3     | Player               |
+| 4     | Active ragdoll bodies |
+| 5     | Partial ragdoll bones |
+
+These are suggestions — adapt to your project's layer scheme. The important
+thing is that `collision_mask` on RagdollTuning overlaps with your environment's
+`collision_layer`.
+
+### Overriding per-character
+
+```gdscript
+var tuning := RagdollTuning.create_default()
+tuning.collision_layer = 1 << 5  # Layer 6
+tuning.collision_mask = 1 | (1 << 5)  # Layers 1 and 6
+kickback_char.ragdoll_tuning = tuning
+```
+
+---
+
+## State Machine
+
+```
+NORMAL ────hit────→ STAGGER ───balance/timer──→ NORMAL
+  │                    │                          ↑
+  │ (ragdoll_prob)     │ (balance_ragdoll)        │
+  ↓                    ↓                          │
+RAGDOLL ──settle──→ GETTING_UP ──converge─────────┘
+  │
+  │ set_persistent(true)
+  ↓
+PERSISTENT ──set_persistent(false)──→ GETTING_UP
+```
+
+### Signal timing
+
+| Transition                | Signal emitted          | When to use                |
+|---------------------------|-------------------------|----------------------------|
+| Any → STAGGER             | `stagger_started`       | Play stumble animation     |
+| STAGGER → NORMAL          | `stagger_finished`      | Return to idle/locomotion  |
+| Any → RAGDOLL             | `ragdoll_started`       | Disable movement, stop AI  |
+| RAGDOLL → GETTING_UP      | `recovery_started`      | Play get-up animation      |
+| GETTING_UP → NORMAL       | `recovery_finished`     | Re-enable movement/AI      |
+| GETTING_UP → RAGDOLL      | `recovery_interrupted`  | Hit during get-up          |
+| Each hit (sub-stagger)    | `hit_absorbed`          | Flinch VFX, UI feedback    |
+| Every STAGGER frame       | `balance_changed`       | UI balance meter           |
+| Pain changes              | `pain_changed`          | Injury animations, limp    |
+| Fatigue changes           | `fatigue_changed`       | Exhaustion animations      |
+| Bone injury               | `region_injured`        | Persistent impairment VFX  |
+
+### Checking state in code
+
+```gdscript
+match kickback_char.get_active_state():
+    ActiveRagdollController.State.NORMAL:
+        # Full animation control
+        pass
+    ActiveRagdollController.State.STAGGER:
+        # On feet but unsteady — consider reducing movement speed
+        pass
+    ActiveRagdollController.State.RAGDOLL, \
+    ActiveRagdollController.State.GETTING_UP, \
+    ActiveRagdollController.State.PERSISTENT:
+        # Physics is driving — skip movement/navigation
+        return
+```
+
+---
+
+## Impact Scoring (Collision Monitoring)
+
+To detect when ragdoll bodies hit the environment (for scoring, sound, VFX),
+use `PhysicsCollisionMonitor` — an optional sibling component.
+
+### Setup
+
+Add `PhysicsCollisionMonitor` as a sibling to your `KickbackCharacter` node.
+It auto-discovers the character and connects after setup completes.
+
+### Connecting
+
+```gdscript
+@onready var monitor: PhysicsCollisionMonitor = $PhysicsCollisionMonitor
+
+func _ready():
+    monitor.body_impact.connect(_on_body_impact)
+
+func _on_body_impact(bone_name: String, velocity: float, contact_body: Node3D):
+    var score = velocity * 10.0
+    if bone_name == "Head":
+        score *= 2.0
+    add_score(score)
+    spawn_impact_vfx(contact_body.global_position)
+```
+
+### Configuration
+
+| Property              | Default | Description                                  |
+|-----------------------|---------|----------------------------------------------|
+| `velocity_threshold`  | 2.0     | Minimum speed (m/s) to emit signal           |
+| `cooldown`            | 0.3     | Per-bone silence period after each emission   |
+| `monitored_bones`     | `[]`    | Empty = all bones; populate to filter         |
+| `filter_self_collisions` | true | Ignore bone-on-bone contacts from same rig   |
+
+### Do NOT route through receive_hit()
+
+`body_impact` is for passive observation only. Calling `receive_hit()` from
+a `body_entered` or `body_impact` callback creates a feedback loop:
+
+```
+hit → impulse → body moves → new contact → receive_hit() → impulse → ...
+```
+
+The per-frame debounce guard in `apply_hit()` mitigates crashes, but the
+pattern is still wrong. Use `body_impact` for scoring and VFX; use
+`receive_hit()` only for discrete external events (bullets, explosions, melee).
+
+---
+
+## Tuning Presets
+
+Factory methods on `RagdollTuning` for common character archetypes:
+
+| Method                | Use case                                    |
+|-----------------------|---------------------------------------------|
+| `create_default()`    | Balanced baseline                           |
+| `create_game_default()` | Action games — amplified micro-reactions  |
+| `create_tank()`       | Tough enemies — high thresholds, fast recovery |
+| `create_agile()`      | Nimble characters — stagger easy, recover fast |
+| `create_fragile()`    | Ragdoll-prone — falls under sustained fire  |
+| `create_responsive()` | Fast-paced action — low stagger, snappy reactions |
+| `create_heavy()`      | Realistic sims — high damping, slow recovery |
+
+### Composing custom presets
+
+Start from a factory method and override specific values:
+
+```gdscript
+var tuning := RagdollTuning.create_responsive()
+tuning.stagger_threshold = 0.5  # harder to stagger than default responsive
+tuning.protected_bones = PackedStringArray(["Foot_L", "Foot_R"])
+kickback_char.ragdoll_tuning = tuning
+```
+
+### Key tuning parameters by game type
+
+**Action / arcade:** Low `stagger_duration` (0.3–0.5), high `recovery_rate`
+(0.8–1.0), high `micro_reaction_strength` (1.2+). Players want snappy
+feedback and fast return to gameplay.
+
+**Realistic / simulation:** High `stagger_duration` (1.5–2.5), low
+`recovery_rate` (0.1–0.3), high `angular_damp` (3.0+). Characters feel
+heavy and grounded.
+
+**Comedy / slapstick:** Low `stagger_strength_floor` (0.05–0.15), high
+`stagger_ragdoll_bonus` (2.0+), low spring strengths across the board.
+Characters flop dramatically.
+
+**Boss enemies:** Use `create_tank()` as a base. High `stagger_threshold`
+(0.2–0.3) so most hits are absorbed. High `protected_bones` to keep legs
+locked. Slow `fatigue_decay` so sustained fire eventually overwhelms.


### PR DESCRIPTION
## Summary

Fixes 7 issues discovered during real game integration, organized into three clusters:

**Collision handling:**
- **#53** — Default `collision_mask` now includes layer 1 (standard environment). Bodies no longer silently fall through default geometry.
- **#54** — Per-frame debounce guard in `apply_hit()` prevents feedback loops when called from `body_entered` callbacks.
- **#52** — New `PhysicsCollisionMonitor` optional component for detecting ragdoll-environment impacts (scoring, VFX, sound) without touching the hit reaction pipeline.

**Setup timing:**
- **#56** — `setup_complete` no longer fires on freed nodes. `_exit_tree()` cancels the deferred await chain.
- **#51** — `PhysicsRigBuilder` emits `bodies_built` signal after rig creation. New `await_bodies()` coroutine.
- **#55** — `initial_state` export ("Normal"/"Ragdoll"/"Persistent") + `queue_ragdoll()` / `queue_persistent()` for spawn-time ragdoll.

**Developer experience:**
- **#57** — Two new tuning presets (`create_responsive()`, `create_heavy()`). New `docs/INTEGRATION.md` covering setup timing, physics layers, state machine, and collision monitoring patterns.

## Test plan

- [x] Open demo scenes — characters collide with floor (layer 1) without custom setup
- [x] Set `initial_state = "Ragdoll"` in inspector — character starts ragdolled
- [x] Call `queue_ragdoll()` immediately after instantiation — works without errors
- [x] Free a KickbackCharacter during its 5-frame setup — no lambda errors in console
- [x] Add `PhysicsCollisionMonitor` sibling — `body_impact` fires on environment hits
- [x] Verify existing shooting_range and stress_test demos still function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)