### PR TITLE
Recalibrate versioning to 0.3.0 + upgrade to Godot 4.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,12 +12,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Download Godot 4.6.1
+      - name: Download Godot 4.7
         run: |
-          wget -q https://github.com/godotengine/godot/releases/download/4.6.1-stable/Godot_v4.6.1-stable_linux.x86_64.zip
-          unzip -q Godot_v4.6.1-stable_linux.x86_64.zip
-          chmod +x Godot_v4.6.1-stable_linux.x86_64
-          mv Godot_v4.6.1-stable_linux.x86_64 godot
+          wget -q https://github.com/godotengine/godot/releases/download/4.7-stable/Godot_v4.7-stable_linux.x86_64.zip
+          unzip -q Godot_v4.7-stable_linux.x86_64.zip
+          chmod +x Godot_v4.7-stable_linux.x86_64
+          mv Godot_v4.7-stable_linux.x86_64 godot
 
       - name: Import project
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+> **Versioning recalibrated 2026-06-19.** `1.0.0` now means full Euphoria parity
+> (see [VERSIONING.md](docs/VERSIONING.md)). The project was re-baselined from `0.8.5`
+> to `0.3.0` to honestly reflect difficulty-weighted progress (~30%). Entries under
+> **Legacy history** below use the old, inconsistent numbering and are **not comparable**
+> to current versions.
+
+## [0.3.0] - 2026-06-19
+
+### Changed
+- **Versioning recalibrated** — re-baselined `0.8.5` → `0.3.0`; `1.0.0` is now full
+  Euphoria parity. Deleted the old `v0.7.0` / `v0.8.0` / `v0.8.5` releases and tags.
+  Added [VERSIONING.md](docs/VERSIONING.md) and [ROADMAP.md](docs/ROADMAP.md) (with a
+  difficulty-weighted parity scorecard) and re-scored
+  [EUPHORIA_COMPARISON.md](docs/EUPHORIA_COMPARISON.md) with honest real/partial/nominal
+  classifications.
+- **Upgraded to Godot 4.7** — `project.godot` features, all documentation version
+  references, and CI bumped from 4.6.1 to 4.7. Validated: clean headless import +
+  76/76 GUT tests pass.
+
+---
+
+## Legacy history (deprecated numbering — pre-recalibration)
+
+These releases used a scheme where the version did **not** track Euphoria parity; the
+numbers below are preserved for reference only and are not comparable to current ones.
+
 ## [0.8.5] - 2026-03-26
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,12 @@
-# Kickback — Physics-Based Reactive Characters for Godot 4.6+
+# Kickback — Physics-Based Reactive Characters for Godot 4.7+
 
 ## What this is
 
-An open-source plugin for Euphoria-like hit reactions in Godot 4.6+.
+An open-source plugin for Euphoria-like hit reactions in Godot 4.7+.
 Characters react dynamically to impacts using physics-driven ragdoll
 and spring-based pose matching. Fully configurable and extensible.
 
-**Engine**: Godot 4.6.1+ with Jolt physics.
+**Engine**: Godot 4.7+ with Jolt physics.
 **Language**: GDScript.
 
 ## Project structure

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for your interest in contributing! Here's how to get started.
 ## Setup
 
 1. **Fork and clone** the repository
-2. **Install Godot 4.6.1+** from [godotengine.org](https://godotengine.org/download)
+2. **Install Godot 4.7+** from [godotengine.org](https://godotengine.org/download)
 3. **Enable Jolt Physics**: Project Settings > Physics > 3D > Physics Engine > Jolt Physics
 4. **Enable the plugin**: Project > Project Settings > Plugins > Kickback > Enable
 5. **Run a demo**: Open any scene from `demo/` to verify setup

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Kickback
 
 [![Tests](https://github.com/blugart-dev/kickback/actions/workflows/tests.yml/badge.svg)](https://github.com/blugart-dev/kickback/actions/workflows/tests.yml)
-[![Godot 4.6+](https://img.shields.io/badge/Godot-4.6%2B-blue?logo=godot-engine)](https://godotengine.org)
+[![Godot 4.7+](https://img.shields.io/badge/Godot-4.7%2B-blue?logo=godot-engine)](https://godotengine.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
-**Physics-based reactive characters for Godot 4.6+**
+**Physics-based reactive characters for Godot 4.7+**
 
 Inspired by NaturalMotion's Euphoria engine (GTA IV/V, Red Dead Redemption). Characters react dynamically to gunshots, explosions, melee hits, and arrows using active ragdoll physics — every hit produces a unique, physically-driven reaction.
 
@@ -34,6 +34,22 @@ Press **F3** in any demo to cycle debug gizmos (bone dots → wireframe → full
   <img src="https://github.com/user-attachments/assets/795372f5-c704-4be7-ac0f-ef4de17ede73" alt="Ball throw demo — NPCs patrol, react to hits, recover with injuries" width="640">
 </p>
 </details>
+
+## Project status
+
+Kickback is **pre-1.0 and actively evolving**. It has a robust *passive* reaction
+foundation — velocity springs, balance sensing, a full state machine, terrain foot IK —
+but the *active self-preservation* behaviors that define
+[Euphoria](docs/EUPHORIA_COMPARISON.md) (stumble-stepping, arm/wall bracing, grabbing,
+procedural poses) are still ahead.
+
+By difficulty-weighted progress toward that goal, the project is at **~30%** — which is
+exactly what the version `0.3.x` is meant to convey. `1.0.0` is reserved for full
+Euphoria parity. See **[ROADMAP.md](docs/ROADMAP.md)** for the scorecard and milestones,
+and **[VERSIONING.md](docs/VERSIONING.md)** for what the numbers mean.
+
+> Today it works well as a hit-reaction system for humanoid (Mixamo-style) rigs.
+> General multi-rig robustness and the self-preservation layer are on the roadmap.
 
 ## Features
 
@@ -66,7 +82,7 @@ Press **F3** in any demo to cycle debug gizmos (bone dots → wireframe → full
 
 ## Requirements
 
-- Godot 4.6.1+
+- Godot 4.7+
 - Jolt Physics (Project Settings > Physics > 3D > Physics Engine = "Jolt Physics")
 
 ## Installation
@@ -178,7 +194,7 @@ Run any scene from `demo/` to see the plugin in action:
 | `ball_throw.tscn` | Throw physics balls, velocity-scaled impact |
 | `tuning_presets.tscn` | 5 characters: Tank/Standard/Loose/Fragile/Protected side-by-side |
 | `protected_bones.tscn` | Protected vs unprotected legs — same hit, different result |
-| `euphoria_showcase.tscn` | All v0.7 features: active resistance, stagger sway, pain, momentum, injuries |
+| `euphoria_showcase.tscn` | Active resistance, stagger sway, pain, momentum, injuries |
 
 ## Collision Layers
 

--- a/addons/kickback/editor/rig_baker.gd.uid
+++ b/addons/kickback/editor/rig_baker.gd.uid
@@ -1,0 +1,1 @@
+uid://bvg6scftikyjq

--- a/addons/kickback/physics_collision_monitor.gd.uid
+++ b/addons/kickback/physics_collision_monitor.gd.uid
@@ -1,0 +1,1 @@
+uid://b1mfvgtngn0rf

--- a/addons/kickback/plugin.cfg
+++ b/addons/kickback/plugin.cfg
@@ -1,7 +1,7 @@
 [plugin]
 
 name="Kickback"
-description="Euphoria-like physics hit reactions for Godot 4.6+ — active ragdoll with stagger, full ragdoll, and recovery"
+description="Euphoria-like physics hit reactions for Godot 4.7+ — active ragdoll with stagger, full ragdoll, and recovery"
 author="Blugart"
-version="0.8.5"
+version="0.3.0"
 script="kickback_plugin.gd"

--- a/docs/EUPHORIA_COMPARISON.md
+++ b/docs/EUPHORIA_COMPARISON.md
@@ -2,26 +2,51 @@
 
 Comparison of the Kickback plugin against NaturalMotion's Euphoria system
 (GTA IV/V, Red Dead Redemption 2, Max Payne 3). Documents missing behaviors
-and systems with difficulty ratings and implementation notes for Godot 4.6+.
+and systems with difficulty ratings and implementation notes for Godot 4.7+.
 
 ## Status Legend
-- [x] Implemented in Kickback
-- [ ] Not yet implemented
+- ✅ **Real** — a genuine behavior, robust
+- 🟡 **Partial** — works narrowly, or a tunable knob doing a fraction of the behavior
+- ⚪ **Nominal** — exists in name/API only; not a meaningful behavior yet
+- ❌ **Missing** — not implemented
 
-## Implemented Features
-- [x] Per-bone spring-based pose matching (velocity springs)
-- [x] Per-bone strength reduction with adjacency spreading
-- [x] 5-state machine (NORMAL/STAGGER/RAGDOLL/GETTING_UP/PERSISTENT)
-- [x] Impact profiles per weapon type (5 presets)
-- [x] Protected bones (selective immunity)
-- [x] Signal-driven architecture (animation-agnostic)
-- [x] Recovery with face-up/face-down orientation detection
-- [x] Budget system for concurrent ragdolls
-- [x] Stagger state with auto-recovery
-- [x] Momentum transfer on ragdoll entry (v0.6)
-- [x] Center of mass balance tracking (v0.6)
+> ⚠️ **Honest accounting.** Counting features equally suggests Kickback is ~67% of the
+> way to Euphoria. That overstates it: several "implemented" items are scalar knobs, not
+> behaviors, and every *active self-preservation* behavior is absent. Difficulty-weighted,
+> real parity is **~30%** (see the [ROADMAP.md](ROADMAP.md) scorecard).
+
+## What's actually built
+
+### Foundation — real and robust
+- ✅ Per-bone spring-based pose matching (velocity springs) — the technical core
+- ✅ Per-bone strength reduction with adjacency spreading
+- ✅ 5-state machine (NORMAL/STAGGER/RAGDOLL/GETTING_UP/PERSISTENT)
+- ✅ Stagger state with balance-driven auto-recovery
+- ✅ Impact profiles per weapon type (5 presets)
+- ✅ Protected bones (selective immunity)
+- ✅ Signal-driven, animation-agnostic architecture
+- ✅ Momentum transfer on ragdoll entry
+- ✅ Center of mass **sensing** vs foot-support polygon
+- ✅ Micro hit reactions (torso bend / head whip / spin torque)
+- ✅ Terrain foot IK (two-bone solver + pelvis drop) — *planting only, not balance-stepping*
+
+### Reactive modulators — partial / nominal
+- 🟡 Recovery with face-up/down detection — single canned animation blend, no get-up variety
+- 🟡 Active Resistance ("bracing") — biases spring *stiffness* toward balance; **no** bracing/limb motion
+- 🟡 Cumulative pain / fatigue — decaying scalars that scale existing strength reductions
+- ⚪ Regional impairment — a per-bone injury scalar feeding a multiplier; no limb-specific behavior
+- ⚪ Threat anticipation — one strength pulse + a signal (a flinch knob, not anticipatory posture)
+- ⚪ Budget system for concurrent ragdolls — `KickbackManager` counter is **not wired** into controllers
+
+### The objective — absent (this is what 1.0 means)
+Every behavior that makes Euphoria *Euphoria* — active balance recovery, stumble steps,
+arm/wall bracing, environmental grabbing, ground crawling, and procedural pose
+generation — is **not yet built**. See the table below.
 
 ## Missing Features — Summary
+
+> Note: ~~struck-through~~ items are addressed in code — see *What's actually built*
+> above for how deeply (several are partial or nominal, not full behaviors).
 
 | # | Feature | Difficulty | Impact | Lines Est. |
 |---|---------|-----------|--------|------------|

--- a/docs/GODOT_CONSTRAINTS.md
+++ b/docs/GODOT_CONSTRAINTS.md
@@ -1,7 +1,7 @@
-# Godot 4.6 Constraints and Workarounds
+# Godot Constraints and Workarounds
 
 Read this BEFORE writing any physics code. These are confirmed issues and
-workarounds specific to Godot 4.6.x with Jolt physics.
+workarounds specific to Godot 4.6+ with Jolt physics.
 
 ## Why we use RigidBody3D instead of PhysicalBone3D for active ragdoll
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,57 @@
+# Roadmap
+
+`1.0.0` = full [Euphoria parity](EUPHORIA_COMPARISON.md). See [VERSIONING.md](VERSIONING.md)
+for what the numbers mean. The minor version tracks difficulty-weighted progress toward
+that goal.
+
+## Euphoria Parity Scorecard
+
+Progress is weighted by **difficulty**, not feature count — the unbuilt behaviors are
+the hard ones. (Counting features equally gives a misleading ~67%; weighted, the honest
+figure is **~30%**.)
+
+| Layer | Status | Weight | Earned |
+|-------|--------|-------:|-------:|
+| **Passive substrate** — velocity springs, 5-state machine, CoM *sensing*, terrain foot IK | ✅ Done & robust | 13 | 13 |
+| **Reactive basics** — strength spread, micro-reactions, momentum transfer, impact profiles, protected bones | ✅ Done | 5 | 5 |
+| **"Soft" modulators** — pain / fatigue / injury, regional impairment, threat anticipation, active-resistance | 🟡 Partial (knobs, not behaviors) | 8 | 2 |
+| **Active self-preservation** — stumble-stepping, arm/wall bracing, environmental grabbing, ground crawling, get-up variety, balance *recovery* | ❌ Absent | 29 | 0 |
+| **Procedural pose "brain"** — target-seeking generated poses | ❌ Absent | 6 | 0 |
+| **Total** | | **61** | **~20 ≈ 30%** |
+
+> Weights are a difficulty/effort judgment, not exact science. By the strictest
+> *behavioral* lens (only active survival behaviors count) parity is ~20%; by raw
+> engineering effort it's ~35%. `0.3.x` anchors the ~30% midpoint. The springs are the
+> muscles — what's missing is the brain telling them what to do.
+
+## Milestones
+
+| Version | Theme | Delivers |
+|---------|-------|----------|
+| **0.3.x** | Re-baseline + hardening | Honest docs & scorecard (this release). Then: fix silent multi-rig degradation, wire-or-remove the budget manager, add runtime smoke tests, generalize beyond Mixamo. |
+| **0.4.0** | Self-Preservation | Procedural stumble steps + arm bracing — the first *active* survival behaviors. |
+| **0.5.0** | Environmental Awareness | Wall/surface bracing + ground crawling. |
+| **0.6.0** | World Interaction | Environmental grabbing (IK reach + physics pins to grab points). |
+| **0.7.0** | Procedural Poses (core) | Replace canned recovery blends with target-seeking generated poses. |
+| **0.8.0** | Balance Recovery | Active balance recovery + get-up variety driven by procedural poses. |
+| **0.9.0** | Production hardening | Multi-rig guarantees, runtime test coverage, API freeze, beta/RC. |
+| **1.0.0** | **Full Euphoria parity** | Committed stable API; the self-preservation layer complete. |
+
+Intermediate minor numbers are recomputed from the scorecard as milestones land.
+
+## Known hardening items (targeted for 0.3.x)
+
+Robustness gaps surfaced by the 2026-06-19 audit — not blockers for using the plugin on
+Mixamo-style rigs, but prerequisites for "general-purpose":
+
+- **Silent multi-rig degradation** — non-Mixamo skeletons that map fine can still lose
+  balance/IK/sway because rig bone names (`Hips`/`Chest`/`Foot_L`…) are hardcoded;
+  `_compute_balance_state` returns zeroed data read as "perfectly balanced," silently
+  disabling the balance→ragdoll path. Should warn or fail loudly.
+- **Budget manager is unwired** — `KickbackManager.request/release_active_ragdoll` is
+  never called by controllers; only the stress-test demo reads the counter.
+- **Spring math is implicitly 60 Hz-bound** — corrections are divided by `delta` with no
+  substepping awareness.
+- **Partial-ragdoll collision shapes don't scale** to character size (the active path does).
+- **No runtime/physics automated tests** — the rig is never built or stepped in CI; all
+  physics behavior is currently eyeballed in demos only.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,0 +1,53 @@
+# Versioning
+
+Kickback uses [Semantic Versioning](https://semver.org/) with one project-specific
+convention:
+
+> **`1.0.0` means full [Euphoria](EUPHORIA_COMPARISON.md) parity** — a character that
+> *actively tries to survive* (steps to catch its balance, braces with its arms, grabs
+> the environment, generates its own recovery poses), not just a ragdoll that gets
+> pushed around.
+
+That is a deliberately high bar. Everything before `1.0.0` is the road toward it.
+
+## What the numbers mean
+
+- **`0.x` (pre-1.0)** — the journey to parity. The **minor** version tracks *rough,
+  difficulty-weighted* progress toward the 1.0 objective: `0.3.x` ≈ "about a third of
+  the way." It is recomputed from the [scorecard](ROADMAP.md) at each milestone, not
+  chosen by feel.
+- **patch (`0.3.1`)** — fixes, polish, and hardening within a milestone; no new
+  objective progress.
+- **pre-release tags (`0.4.0-alpha`, `-beta`, `-rc`)** — in-progress milestones.
+- **`1.0.0`** — full Euphoria parity **plus** a committed, stable public API.
+
+Because `1.0` is the *vision*, Kickback will stay `0.x` for a long time even though it
+is already usable today. That is intentional: the number reflects distance to the
+goal, not whether the plugin works.
+
+## The 2026-06-19 recalibration
+
+Kickback previously climbed to `0.8.5`, which read as ~85% complete. Against the
+objective above that was misleading — the entire active self-preservation layer (the
+part that *is* Euphoria) was unbuilt (~0%). Difficulty-weighted, the project was closer
+to **~30%**.
+
+To make the number honest, the project was **re-baselined `0.8.5` → `0.3.0`**:
+
+- The `v0.7.0` / `v0.8.0` / `v0.8.5` GitHub releases and git tags were deleted. (Kickback
+  was never published to the Godot Asset Library and had no forks, so the blast radius
+  was effectively zero.)
+- `CHANGELOG.md` preserves the old entries under **Legacy history (deprecated
+  numbering)** — those numbers are **not comparable** to current ones.
+- A few numbers (`0.3.0`, `0.7.0`, `0.8.0`) are reused under the new scheme; the
+  originals are deleted and clearly marked legacy.
+
+This is a one-time correction, permissible precisely because we are pre-1.0 — SemVer
+makes no compatibility guarantee below `1.0.0`.
+
+## Cutting a release
+
+1. Update `version=` in `addons/kickback/plugin.cfg`.
+2. Update `CHANGELOG.md`.
+3. Tag with a `v` prefix and push: `git tag v0.3.0 && git push origin v0.3.0`.
+4. One-time, so tags sort by version not lexically: `git config tag.sort version:refname`.

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="kickback"
-config/features=PackedStringArray("4.6", "Forward Plus")
+config/features=PackedStringArray("4.7", "Forward Plus")
 config/icon="res://icon.svg"
 
 [editor_plugins]

--- a/test/test_foot_ik.gd.uid
+++ b/test/test_foot_ik.gd.uid
@@ -1,0 +1,1 @@
+uid://btk57k0b84c4k


### PR DESCRIPTION
## Summary
Two pieces of project housekeeping, on one branch because they touch overlapping files.

### 1. Versioning recalibration (0.8.5 → 0.3.0)
The old numbering implied ~85% completion, but `1.0` was defined as full Euphoria parity — and the entire active self-preservation layer is unbuilt (~0%). The number was tracking editor polish, not the objective.

- **`1.0.0` now means full Euphoria parity** (see `docs/VERSIONING.md`).
- Re-baselined to **`0.3.0`** (~30% difficulty-weighted — see the scorecard in `docs/ROADMAP.md`).
- Deleted the old `v0.7.0`/`v0.8.0`/`v0.8.5` GitHub releases + tags (not on AssetLib, 0 forks → ~zero blast radius). Recreatable from commits `12ce5ad`/`3933a81`/`e5a3b24` if ever needed.
- `CHANGELOG.md`: old entries moved under **Legacy history (deprecated numbering)**.
- `docs/EUPHORIA_COMPARISON.md`: re-scored with honest **real / partial / nominal** classifications (e.g. budget manager = unwired; "active resistance" = spring-stiffness bias, not bracing motion).
- `README.md`: new **Project status** section.

### 2. Godot 4.7 upgrade
- `project.godot` features, all doc version refs, and CI (`tests.yml`) bumped 4.6.1 → 4.7.
- Validated: **clean headless import + 76/76 GUT tests pass** under 4.7.

## Notes
- No engine/runtime code changed — docs, version strings, CI, and 3 previously-untracked `.uid` files only.
- `demo/ik_research.tscn` (pre-existing WIP) is intentionally **left out** of this PR.

## Follow-ups (not in this PR)
- Hardening for `0.3.x`: fix the silent multi-rig balance degradation (`active_ragdoll_controller.gd:848-850`), wire/remove the budget manager, add runtime physics smoke tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)