### PR TITLE
De-hardcode bone roles + collision layers; complete multi-rig balance/IK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,20 @@
   references, and CI bumped from 4.6.1 to 4.7. Validated: clean headless import +
   76/76 GUT tests pass.
 
+### Added
+- **Semantic role accessors on `RagdollProfile`** — `get_root_rig`, `get_chest_rig`,
+  `get_head_rig`, `get_torso_rigs`, `get_foot_rigs`, `get_leg_chain`, `get_all_leg_rigs`,
+  `is_leg_rig`, `get_leg_side`, and `get_root_skeleton_bone`, backed by overridable
+  `root_rig`/`chest_rig`/`head_rig`/`torso_rigs`/`foot_rigs`/`left_leg_chain`/`right_leg_chain`
+  export fields (defaulting to the Mixamo convention). The controller, `FootIKSolver`, and
+  debug HUD query these instead of hardcoding `"Hips"`/`"Foot_L"`/…, so non-Mixamo rigs work
+  by overriding the role fields. List accessors filter out names that don't map to a defined
+  bone, so a missing body degrades gracefully. `validate_against_skeleton` now flags role
+  names that don't reference a defined rig bone.
+- **`KickbackLayers`** — named collision-layer constants (active ragdoll = UI layer 4,
+  partial ragdoll = UI layer 5) replacing magic numbers in `KickbackRaycast` and
+  `SkeletonDetector`.
+
 ### Fixed
 - **Multi-rig safety** — balance-driven stagger/ragdoll no longer silently disables on
   skeletons that don't expose `Foot_L`/`Foot_R` bodies. `_compute_balance_state` now
@@ -27,6 +41,14 @@
 - **PhysicsCollisionMonitor** disconnects its `body_entered` signals on `_exit_tree`
   (was leaking connections to bodies that outlive the monitor); `max_contacts_reported`
   now uses `maxi` (was `maxf` assigned into an int property).
+- **Multi-rig balance/IK completed** — the controller, `FootIKSolver`, and debug HUD now
+  resolve root/torso/feet/leg-side bones through `RagdollProfile`'s semantic roles instead
+  of hardcoded Mixamo names, and `_compute_balance_state` supports any number of feet.
+  Non-Mixamo rigs gain working balance/IK/sway by setting the role fields (previously they
+  silently lost them). Completes the PR #60 `has_support` guard.
+- **`RagdollProfile.root_bone`** no longer defaults to the Mixamo-specific `"mixamorig_Hips"`.
+  It defaults to empty and derives from `root_rig` via `get_root_skeleton_bone()`, so the
+  partial-ragdoll recursion guard is correct on any rig.
 
 ### Changed
 - **Budget manager wired in** — `ActiveRagdollController` requests a slot from
@@ -41,6 +63,10 @@
   Custom character driven by the live, now-scrollable slider panel. Preset tunings reuse
   the `RagdollTuning.create_*` factory methods where available. The patrol/recover/resume
   loop `ball_throw` demonstrated already lives in `animated_npc`.
+- **Partial-ragdoll collision shapes scale to the character** —
+  `SkeletonDetector.populate_physical_bones` reuses the active-rig shape pipeline
+  (`create_profile_from_skeleton` + `create_collision_shape`) instead of fixed 0.15 m
+  boxes / 0.05 m capsules.
 
 ### Removed
 - Dead passive-tracking path in `SpringResolver` (springs are always active) and its 5

--- a/addons/kickback/active_ragdoll_controller.gd
+++ b/addons/kickback/active_ragdoll_controller.gd
@@ -74,6 +74,15 @@ var _profile: RagdollProfile
 var _tuning: RagdollTuning
 var _foot_ik: FootIKSolver
 
+# Cached semantic role rig-names, resolved from the profile (see RagdollProfile roles).
+# Consumers query these instead of hardcoding "Hips"/"Foot_L"/... so non-Mixamo rigs work.
+var _root_rig: String = "Hips"
+var _chest_rig: String = "Chest"
+var _head_rig: String = "Head"
+var _foot_rigs: PackedStringArray = ["Foot_L", "Foot_R"]
+var _torso_rigs: PackedStringArray = ["Hips", "Spine", "Chest"]
+var _leg_rig_set: Dictionary = {}  # rig_name → true, O(1) leg membership
+
 # Budget manager (optional, discovered via group). Holds at most one ragdoll slot.
 var _manager: Node = null
 var _holds_ragdoll_slot: bool = false
@@ -110,6 +119,7 @@ signal region_injured(rig_name: String, severity: float)
 func configure(profile: RagdollProfile, tuning: RagdollTuning) -> void:
 	_profile = profile
 	_tuning = tuning
+	_resolve_roles()
 	_rebuild_protected_set()
 
 
@@ -130,6 +140,21 @@ func _ensure_config() -> void:
 		_profile = RagdollProfile.create_mixamo_default()
 	if not _tuning:
 		_tuning = RagdollTuning.create_default()
+	_resolve_roles()
+
+
+## Resolves and caches semantic role rig-names from the profile.
+func _resolve_roles() -> void:
+	if not _profile:
+		return
+	_root_rig = _profile.get_root_rig()
+	_chest_rig = _profile.get_chest_rig()
+	_head_rig = _profile.get_head_rig()
+	_foot_rigs = _profile.get_foot_rigs()
+	_torso_rigs = _profile.get_torso_rigs()
+	_leg_rig_set.clear()
+	for leg: String in _profile.get_all_leg_rigs():
+		_leg_rig_set[leg] = true
 
 
 func _rebuild_protected_set() -> void:
@@ -195,7 +220,7 @@ func _physics_process(delta: float) -> void:
 	if not _foot_ik and _tuning and _tuning.foot_ik_enabled and _character_root:
 		if not _spring.get_all_bone_names().is_empty():
 			_foot_ik = FootIKSolver.new()
-			if not _foot_ik.initialize(_spring, _tuning, _character_root, _rig_builder):
+			if not _foot_ik.initialize(_spring, _tuning, _character_root, _rig_builder, _profile):
 				push_warning("ActiveRagdollController: foot IK disabled (missing leg bones)")
 				_foot_ik = null
 
@@ -573,7 +598,7 @@ func anticipate_threat(threat_dir: Vector3, urgency: float = 0.5) -> void:
 	var pulse_intensity := urgency * _tuning.threat_anticipation_strength
 	if pulse_intensity > 0.01:
 		var bodies := _rig_builder.get_bodies()
-		var hips_body: RigidBody3D = bodies.get("Hips")
+		var hips_body: RigidBody3D = bodies.get(_root_rig)
 		if not hips_body:
 			return
 		# Find the bone closest to the threat direction for targeted pulse
@@ -623,6 +648,19 @@ func get_state_name() -> String:
 	return "UNKNOWN"
 
 
+## Resolved root rig name (for the debug HUD / external queries).
+func get_root_rig() -> String:
+	return _root_rig
+
+## Resolved head rig name.
+func get_head_rig() -> String:
+	return _head_rig
+
+## Resolved foot rig names.
+func get_foot_rigs() -> PackedStringArray:
+	return _foot_rigs
+
+
 # ── State Transitions ───────────────────────────────────────────────────────
 
 func _full_ragdoll() -> void:
@@ -662,12 +700,12 @@ func _start_recovery() -> void:
 	state_changed.emit(_state)
 
 	var bodies := _rig_builder.get_bodies()
-	var hip_body: RigidBody3D = bodies.get("Hips")
+	var hip_body: RigidBody3D = bodies.get(_root_rig)
 	if not hip_body:
 		_finish_recovery()
 		return
-	var chest_body: RigidBody3D = bodies.get("Chest")
-	var head_body: RigidBody3D = bodies.get("Head")
+	var chest_body: RigidBody3D = bodies.get(_chest_rig)
+	var head_body: RigidBody3D = bodies.get(_head_rig)
 
 	# Detect orientation BEFORE moving root
 	var face_up := true
@@ -862,9 +900,14 @@ func _compute_average_strength_ratio() -> float:
 func _compute_balance_state() -> Dictionary:
 	var empty := {"com": Vector3.ZERO, "support_center": Vector3.ZERO, "balance_ratio": 0.0, "imbalance_dir": Vector2.ZERO, "has_support": false}
 	var bodies := _rig_builder.get_bodies()
-	var foot_l: RigidBody3D = bodies.get("Foot_L")
-	var foot_r: RigidBody3D = bodies.get("Foot_R")
-	if not foot_l or not foot_r:
+
+	# Collect the foot bodies that actually exist (role-driven, multi-rig safe).
+	var feet: Array[RigidBody3D] = []
+	for foot_rig: String in _foot_rigs:
+		var fb: RigidBody3D = bodies.get(foot_rig)
+		if fb:
+			feet.append(fb)
+	if feet.is_empty():
 		return empty
 
 	var com := Vector3.ZERO
@@ -876,9 +919,15 @@ func _compute_balance_state() -> Dictionary:
 		return empty
 	com /= total_mass
 
-	var support_center := (foot_l.global_position + foot_r.global_position) * 0.5
-	var foot_spread := foot_l.global_position.distance_to(foot_r.global_position)
-	var support_radius := maxf(foot_spread * 0.5, _tuning.balance_support_radius_min)
+	var support_center := Vector3.ZERO
+	for f: RigidBody3D in feet:
+		support_center += f.global_position
+	support_center /= feet.size()
+
+	# Support radius = furthest foot from the centre (= half the spread for two feet).
+	var support_radius := _tuning.balance_support_radius_min
+	for f: RigidBody3D in feet:
+		support_radius = maxf(support_radius, f.global_position.distance_to(support_center))
 
 	var com_xz := Vector2(com.x, com.z)
 	var support_xz := Vector2(support_center.x, support_center.z)
@@ -929,21 +978,23 @@ func _apply_micro_reaction(hit_dir: Vector3, profile: ImpactProfile) -> void:
 	var intensity: float = profile.strength_reduction * _tuning.micro_reaction_strength
 
 	# Head whip: torque pushes head in hit direction
-	var head: RigidBody3D = bodies.get("Head")
+	var head: RigidBody3D = bodies.get(_head_rig)
 	if head:
 		var whip_torque := hit_dir.cross(Vector3.UP) * intensity * _tuning.micro_head_whip_strength
 		head.apply_torque_impulse(whip_torque)
 
-	# Torso bend: spine/chest bend away from hit direction
-	for bone_name: String in ["Spine", "Chest"]:
-		var bone_body: RigidBody3D = bodies.get(bone_name)
+	# Torso bend: spine/chest bend away from hit direction (skip the root/pelvis)
+	for torso_rig: String in _torso_rigs:
+		if torso_rig == _root_rig:
+			continue
+		var bone_body: RigidBody3D = bodies.get(torso_rig)
 		if bone_body:
 			var bend_torque := (-hit_dir).cross(Vector3.UP) * intensity * _tuning.micro_torso_bend_strength
 			bone_body.apply_torque_impulse(bend_torque)
 
 	# Spin: high-caliber hits twist the torso around Y axis
 	if profile.base_impulse > 10.0:
-		var hips: RigidBody3D = bodies.get("Hips")
+		var hips: RigidBody3D = bodies.get(_root_rig)
 		if hips:
 			var spin_strength := profile.base_impulse * _tuning.micro_spin_strength * 0.01
 			hips.apply_torque_impulse(Vector3.UP * spin_strength * signf(hit_dir.x))
@@ -1002,7 +1053,7 @@ func _release_ragdoll_slot() -> void:
 
 func _apply_directional_bracing(hit_dir: Vector3) -> void:
 	var bodies := _rig_builder.get_bodies()
-	var hips_body: RigidBody3D = bodies.get("Hips")
+	var hips_body: RigidBody3D = bodies.get(_root_rig)
 	if not hips_body:
 		return
 	var center := hips_body.global_position
@@ -1045,15 +1096,7 @@ func _apply_directional_bracing(hit_dir: Vector3) -> void:
 
 
 func _is_leg_bone(rig_name: String) -> bool:
-	return rig_name.begins_with("UpperLeg") or rig_name.begins_with("LowerLeg") or rig_name.begins_with("Foot")
-
-
-func _get_bone_side(rig_name: String) -> String:
-	if rig_name.ends_with("_L"):
-		return "L"
-	elif rig_name.ends_with("_R"):
-		return "R"
-	return ""
+	return _leg_rig_set.has(rig_name)
 
 
 func _apply_active_resistance(delta: float) -> void:
@@ -1089,22 +1132,25 @@ func _apply_active_resistance(delta: float) -> void:
 	var velocity_multiplier := 1.0 + velocity_factor * _tuning.resistance_velocity_spike
 
 	# Determine which leg is load-bearing (closer to the fall direction)
+	# Load-bearing leg = the foot furthest in the fall direction; brace its side.
 	var brace_side := ""
-	if _tuning.resistance_leg_brace > 0.0:
-		var foot_l: RigidBody3D = bodies.get("Foot_L")
-		var foot_r: RigidBody3D = bodies.get("Foot_R")
-		if foot_l and foot_r and imbalance_dir.length_squared() > 0.001:
-			var support_xz := Vector2(support_center.x, support_center.z)
-			var fl_xz := Vector2(foot_l.global_position.x, foot_l.global_position.z)
-			var fr_xz := Vector2(foot_r.global_position.x, foot_r.global_position.z)
-			var l_offset := fl_xz - support_xz
-			var r_offset := fr_xz - support_xz
-			var l_dot: float = l_offset.normalized().dot(imbalance_dir) if l_offset.length_squared() > 0.001 else 0.0
-			var r_dot: float = r_offset.normalized().dot(imbalance_dir) if r_offset.length_squared() > 0.001 else 0.0
-			brace_side = "L" if l_dot > r_dot else "R"
+	if _tuning.resistance_leg_brace > 0.0 and imbalance_dir.length_squared() > 0.001:
+		var support_xz := Vector2(support_center.x, support_center.z)
+		var best_dot := -INF
+		for foot_rig: String in _foot_rigs:
+			var fb: RigidBody3D = bodies.get(foot_rig)
+			if not fb:
+				continue
+			var f_offset := Vector2(fb.global_position.x, fb.global_position.z) - support_xz
+			if f_offset.length_squared() <= 0.001:
+				continue
+			var d := f_offset.normalized().dot(imbalance_dir)
+			if d > best_dot:
+				best_dot = d
+				brace_side = _profile.get_leg_side(foot_rig)
 
 	# Hips center for bone offset computation
-	var hips_body: RigidBody3D = bodies.get("Hips")
+	var hips_body: RigidBody3D = bodies.get(_root_rig)
 	if not hips_body:
 		return
 	var hips_center := Vector2(hips_body.global_position.x, hips_body.global_position.z)
@@ -1135,7 +1181,7 @@ func _apply_active_resistance(delta: float) -> void:
 
 		# Component 3: Load-bearing leg bracing
 		if _tuning.resistance_leg_brace > 0.0 and brace_side != "":
-			if _is_leg_bone(rig_name) and _get_bone_side(rig_name) == brace_side:
+			if _is_leg_bone(rig_name) and _profile.get_leg_side(rig_name) == brace_side:
 				boost += balance_ratio * _tuning.resistance_leg_brace * resistance_capacity
 
 		# Apply velocity multiplier and clamp to effective base
@@ -1152,7 +1198,7 @@ func _apply_stagger_sway(_delta: float) -> void:
 		return
 
 	var bodies := _rig_builder.get_bodies()
-	var hips: RigidBody3D = bodies.get("Hips")
+	var hips: RigidBody3D = bodies.get(_root_rig)
 	if not hips:
 		return
 
@@ -1171,19 +1217,22 @@ func _apply_stagger_sway(_delta: float) -> void:
 	var perp := _stagger_hit_dir.cross(Vector3.UP).normalized()
 	var force := (_stagger_hit_dir * osc_primary + perp * osc_secondary) * _tuning.stagger_sway_strength * decay
 
-	# Apply force to core bones (decreasing intensity up the chain)
+	# Apply full force to the root, then the rest of the torso with falloff
+	# (chest_rig uses the chest falloff; other torso bones use the spine falloff).
 	hips.apply_central_force(force)
-	var spine: RigidBody3D = bodies.get("Spine")
-	if spine:
-		spine.apply_central_force(force * _tuning.stagger_sway_spine_falloff)
-	var chest: RigidBody3D = bodies.get("Chest")
-	if chest:
-		chest.apply_central_force(force * _tuning.stagger_sway_chest_falloff)
 
 	# Upper body twist: independent torso rotation at a third frequency
 	var twist_osc := sin(t * freq * _tuning.stagger_sway_twist_ratio * TAU)
 	var torque := Vector3.UP * _tuning.stagger_sway_strength * twist_osc * decay * _tuning.stagger_sway_twist
-	if spine:
-		spine.apply_torque(torque)
-	if chest:
-		chest.apply_torque(torque * _tuning.stagger_sway_chest_falloff)
+
+	for torso_rig: String in _torso_rigs:
+		if torso_rig == _root_rig:
+			continue
+		var tb: RigidBody3D = bodies.get(torso_rig)
+		if not tb:
+			continue
+		var is_chest := torso_rig == _chest_rig
+		var force_falloff: float = _tuning.stagger_sway_chest_falloff if is_chest else _tuning.stagger_sway_spine_falloff
+		tb.apply_central_force(force * force_falloff)
+		var twist_falloff: float = _tuning.stagger_sway_chest_falloff if is_chest else 1.0
+		tb.apply_torque(torque * twist_falloff)

--- a/addons/kickback/foot_ik_solver.gd
+++ b/addons/kickback/foot_ik_solver.gd
@@ -20,6 +20,16 @@ var _lower_leg_len: float = 0.0
 var _bone_idx: Dictionary = {}  # rig_name → skeleton bone index
 var _hips_idx: int = -1
 
+# Resolved role rig-names (from RagdollProfile semantic roles). Defaults match the
+# Mixamo convention; initialize() overwrites them from the profile.
+var _root: String = "Hips"
+var _upper_l: String = "UpperLeg_L"
+var _lower_l: String = "LowerLeg_L"
+var _foot_l: String = "Foot_L"
+var _upper_r: String = "UpperLeg_R"
+var _lower_r: String = "LowerLeg_R"
+var _foot_r: String = "Foot_R"
+
 var _ik_weight_l: float = 0.0
 var _ik_weight_r: float = 0.0
 var _pelvis_offset: float = 0.0
@@ -39,7 +49,7 @@ var _pin_pos_r: Vector3 = Vector3.ZERO
 
 
 func initialize(spring: SpringResolver, tuning: RagdollTuning, character_root: Node3D,
-		rig_builder: PhysicsRigBuilder) -> bool:
+		rig_builder: PhysicsRigBuilder, profile: RagdollProfile) -> bool:
 	_spring = spring
 	_tuning = tuning
 	_character_root = character_root
@@ -49,22 +59,35 @@ func initialize(spring: SpringResolver, tuning: RagdollTuning, character_root: N
 	if not _skeleton or not _world_3d:
 		return false
 
-	# Look up bone indices for all required leg bones + hips
-	var required := ["UpperLeg_L", "LowerLeg_L", "Foot_L", "UpperLeg_R", "LowerLeg_R", "Foot_R"]
-	for rig_name: String in required:
+	# Resolve leg chains + root from the profile's semantic roles. A chain is empty
+	# if incomplete (foot IK needs hip→knee→foot), in which case IK is unavailable.
+	var left := profile.get_leg_chain("L")
+	var right := profile.get_leg_chain("R")
+	_root = profile.get_root_rig()
+	if left.size() != 3 or right.size() != 3 or _root == "":
+		return false
+	_upper_l = left[0]
+	_lower_l = left[1]
+	_foot_l = left[2]
+	_upper_r = right[0]
+	_lower_r = right[1]
+	_foot_r = right[2]
+
+	# Look up bone indices for all required leg bones + root
+	for rig_name: String in [_upper_l, _lower_l, _foot_l, _upper_r, _lower_r, _foot_r]:
 		var idx := spring.get_bone_idx(rig_name)
 		if idx < 0:
 			return false
 		_bone_idx[rig_name] = idx
 
-	_hips_idx = spring.get_bone_idx("Hips")
+	_hips_idx = spring.get_bone_idx(_root)
 	if _hips_idx < 0:
 		return false
 
 	# Compute bone lengths from rest poses (use left leg — symmetric skeleton)
-	var ul := _skeleton.get_bone_global_rest(_bone_idx["UpperLeg_L"])
-	var ll := _skeleton.get_bone_global_rest(_bone_idx["LowerLeg_L"])
-	var fl := _skeleton.get_bone_global_rest(_bone_idx["Foot_L"])
+	var ul := _skeleton.get_bone_global_rest(_bone_idx[_upper_l])
+	var ll := _skeleton.get_bone_global_rest(_bone_idx[_lower_l])
+	var fl := _skeleton.get_bone_global_rest(_bone_idx[_foot_l])
 	_upper_leg_len = ul.origin.distance_to(ll.origin)
 	_lower_leg_len = ll.origin.distance_to(fl.origin)
 
@@ -73,8 +96,8 @@ func initialize(spring: SpringResolver, tuning: RagdollTuning, character_root: N
 
 	# Cache foot body refs for collision management
 	var bodies := rig_builder.get_bodies()
-	_foot_body_l = bodies.get("Foot_L")
-	_foot_body_r = bodies.get("Foot_R")
+	_foot_body_l = bodies.get(_foot_l)
+	_foot_body_r = bodies.get(_foot_r)
 	if _foot_body_l:
 		_foot_mask_l = _foot_body_l.collision_mask
 	if _foot_body_r:
@@ -159,12 +182,12 @@ func _solve_ik(delta: float, use_pins: bool) -> void:
 	# Animation poses
 	var hips_anim := sg * _spring.get_animation_bone_global(_hips_idx)
 	var hip_y := hips_anim.origin.y
-	var upper_l := sg * _spring.get_animation_bone_global(_bone_idx["UpperLeg_L"])
-	var lower_l := sg * _spring.get_animation_bone_global(_bone_idx["LowerLeg_L"])
-	var foot_l := sg * _spring.get_animation_bone_global(_bone_idx["Foot_L"])
-	var upper_r := sg * _spring.get_animation_bone_global(_bone_idx["UpperLeg_R"])
-	var lower_r := sg * _spring.get_animation_bone_global(_bone_idx["LowerLeg_R"])
-	var foot_r := sg * _spring.get_animation_bone_global(_bone_idx["Foot_R"])
+	var upper_l := sg * _spring.get_animation_bone_global(_bone_idx[_upper_l])
+	var lower_l := sg * _spring.get_animation_bone_global(_bone_idx[_lower_l])
+	var foot_l := sg * _spring.get_animation_bone_global(_bone_idx[_foot_l])
+	var upper_r := sg * _spring.get_animation_bone_global(_bone_idx[_upper_r])
+	var lower_r := sg * _spring.get_animation_bone_global(_bone_idx[_lower_r])
+	var foot_r := sg * _spring.get_animation_bone_global(_bone_idx[_foot_r])
 
 	# Foot XZ source: animation (NORMAL) or pinned positions (STAGGER)
 	var foot_xz_l := Vector2(foot_l.origin.x, foot_l.origin.z)
@@ -240,7 +263,7 @@ func _solve_ik(delta: float, use_pins: bool) -> void:
 		var ft := Vector3(foot_xz_l.x, gpos_l.y + _tuning.foot_ik_ankle_height, foot_xz_l.y)
 		var ik := _solve_two_bone_ik(upper_l.origin + ps, ft, lower_l.origin + ps, gnorm_l, foot_l)
 		if not ik.is_empty():
-			_blend_leg(overrides, "UpperLeg_L", "LowerLeg_L", "Foot_L",
+			_blend_leg(overrides, _upper_l, _lower_l, _foot_l,
 				upper_l, lower_l, foot_l, ik, _ik_weight_l, ps)
 
 	# Solve right leg
@@ -248,7 +271,7 @@ func _solve_ik(delta: float, use_pins: bool) -> void:
 		var ft := Vector3(foot_xz_r.x, gpos_r.y + _tuning.foot_ik_ankle_height, foot_xz_r.y)
 		var ik := _solve_two_bone_ik(upper_r.origin + ps, ft, lower_r.origin + ps, gnorm_r, foot_r)
 		if not ik.is_empty():
-			_blend_leg(overrides, "UpperLeg_R", "LowerLeg_R", "Foot_R",
+			_blend_leg(overrides, _upper_r, _lower_r, _foot_r,
 				upper_r, lower_r, foot_r, ik, _ik_weight_r, ps)
 
 	_spring.set_target_overrides(overrides)
@@ -339,7 +362,7 @@ func _raycast_ground(origin: Vector3, distance: float) -> Dictionary:
 
 func _boost_leg_strength() -> void:
 	var target_str := _tuning.foot_ik_stagger_leg_strength
-	for leg_name: String in ["UpperLeg_L", "LowerLeg_L", "Foot_L", "UpperLeg_R", "LowerLeg_R", "Foot_R"]:
+	for leg_name: String in [_upper_l, _lower_l, _foot_l, _upper_r, _lower_r, _foot_r]:
 		var base := _spring.get_base_strength(leg_name)
 		var floor_val := base * target_str
 		if _spring.get_bone_strength(leg_name) < floor_val:

--- a/addons/kickback/kickback_layers.gd
+++ b/addons/kickback/kickback_layers.gd
@@ -1,0 +1,22 @@
+## Centralized collision-layer convention for Kickback physics rigs.
+## Single source of truth for the layer numbers used across the plugin, so the
+## 4/5 ragdoll convention isn't re-spelled as magic numbers (8, 16, 24, 18...).
+##
+## Naming: *_BIT is the 0-based shift; *_LAYER is the bitmask (1 << BIT), which
+## equals the (BIT + 1)-th layer in the Godot inspector UI.
+class_name KickbackLayers
+
+## Active-ragdoll RigidBody3D bodies (Active Ragdoll mode). UI layer 4.
+const ACTIVE_RAGDOLL_BIT := 3
+const ACTIVE_RAGDOLL_LAYER := 1 << ACTIVE_RAGDOLL_BIT   # 8
+
+## Partial-ragdoll PhysicalBone3D bodies (Partial Ragdoll mode). UI layer 5.
+const PARTIAL_RAGDOLL_BIT := 4
+const PARTIAL_RAGDOLL_LAYER := 1 << PARTIAL_RAGDOLL_BIT  # 16
+
+## Combined mask matching either ragdoll layer (used by hit raycasts).
+const BOTH_RAGDOLL_MASK := ACTIVE_RAGDOLL_LAYER | PARTIAL_RAGDOLL_LAYER  # 24
+
+## Environment / world geometry that partial-ragdoll bones collide against. UI layer 2.
+const ENVIRONMENT_BIT := 1
+const ENVIRONMENT_LAYER := 1 << ENVIRONMENT_BIT          # 2

--- a/addons/kickback/kickback_layers.gd.uid
+++ b/addons/kickback/kickback_layers.gd.uid
@@ -1,0 +1,1 @@
+uid://dtqbaadwdojes

--- a/addons/kickback/kickback_raycast.gd
+++ b/addons/kickback/kickback_raycast.gd
@@ -8,12 +8,9 @@
 ## [/codeblock]
 class_name KickbackRaycast
 
-## Collision layer bit for active ragdoll RigidBody3D nodes (layer 4 in UI).
-const ACTIVE_RAGDOLL_BIT := 3
-## Collision layer bit for partial ragdoll PhysicalBone3D nodes (layer 5 in UI).
-const PARTIAL_RAGDOLL_BIT := 4
-## Default collision mask targeting both ragdoll layers.
-const DEFAULT_MASK := (1 << ACTIVE_RAGDOLL_BIT) | (1 << PARTIAL_RAGDOLL_BIT)
+## Default collision mask targeting both ragdoll layers (active + partial).
+## See [KickbackLayers] for the layer convention.
+const DEFAULT_MASK := KickbackLayers.BOTH_RAGDOLL_MASK
 
 
 ## Performs a raycast from the viewport camera through [param screen_pos] and

--- a/addons/kickback/partial_ragdoll_controller.gd
+++ b/addons/kickback/partial_ragdoll_controller.gd
@@ -100,7 +100,7 @@ func _get_bone_chain(bone_name: String) -> PackedStringArray:
 	var parent_idx := _skeleton.get_bone_parent(hit_idx)
 	if parent_idx >= 0:
 		var parent_name := _skeleton.get_bone_name(parent_idx)
-		if parent_name in _bone_map and parent_name != _profile.root_bone:
+		if parent_name in _bone_map and parent_name != _profile.get_root_skeleton_bone():
 			chain.append(parent_name)
 
 	return chain

--- a/addons/kickback/resources/ragdoll_profile.gd
+++ b/addons/kickback/resources/ragdoll_profile.gd
@@ -17,15 +17,115 @@ extends Resource
 ## Skeleton bones not in the physics rig that need interpolated pose overrides.
 @export var intermediate_bones: Array[IntermediateBoneEntry] = []
 
+@export_group("Semantic Roles")
+## Rig name of the pelvis/root body — centre-of-mass base, root motion, sway anchor.
+@export var root_rig: String = "Hips"
+## Rig name of the upper-torso/chest body — head-whip + arm attach point.
+@export var chest_rig: String = "Chest"
+## Rig name of the head body — head-whip, state gizmos.
+@export var head_rig: String = "Head"
+## Rig names of the torso/core bodies, root→top. Recovery pose blend + sway falloff.
+@export var torso_rigs: PackedStringArray = ["Hips", "Spine", "Chest"]
+## Rig names of the foot bodies — balance support polygon, foot IK, CoM gizmos.
+@export var foot_rigs: PackedStringArray = ["Foot_L", "Foot_R"]
+## Ordered left leg chain, hip→knee→foot, used by foot IK.
+@export var left_leg_chain: PackedStringArray = ["UpperLeg_L", "LowerLeg_L", "Foot_L"]
+## Ordered right leg chain, hip→knee→foot, used by foot IK.
+@export var right_leg_chain: PackedStringArray = ["UpperLeg_R", "LowerLeg_R", "Foot_R"]
+
 @export_group("Special Bones")
 ## Skeleton bone name used as recursion guard in partial ragdoll chain traversal.
-@export var root_bone: String = "mixamorig_Hips"
+## Leave empty to derive it from [member root_rig] — see [method get_root_skeleton_bone].
+@export var root_bone: String = ""
+
+
+# ── Semantic role accessors ─────────────────────────────────────────────────
+# Consumers (controller, foot IK, debug HUD) query these instead of hardcoding
+# rig-name literals, so non-Mixamo rigs work by overriding the role fields above.
+# List accessors filter out names that don't map to a defined bone, so a missing
+# body degrades gracefully instead of resolving to a null lookup.
+
+## Returns the root rig name if it maps to a defined bone, else "".
+func get_root_rig() -> String:
+	return root_rig if _has_rig(root_rig) else ""
+
+## Returns the chest rig name if it maps to a defined bone, else "".
+func get_chest_rig() -> String:
+	return chest_rig if _has_rig(chest_rig) else ""
+
+## Returns the head rig name if it maps to a defined bone, else "".
+func get_head_rig() -> String:
+	return head_rig if _has_rig(head_rig) else ""
+
+## Returns the torso/core rig names that map to defined bones (root→top order).
+func get_torso_rigs() -> PackedStringArray:
+	return _filter_present(torso_rigs)
+
+## Returns the foot rig names that map to defined bones.
+func get_foot_rigs() -> PackedStringArray:
+	return _filter_present(foot_rigs)
+
+## Returns the ordered leg chain (hip→knee→foot) for [param side] ("L" or "R"),
+## or an empty array if the chain is incomplete (foot IK needs all three links).
+func get_leg_chain(side: String) -> PackedStringArray:
+	var chain := left_leg_chain if side == "L" else right_leg_chain
+	var present := _filter_present(chain)
+	return present if present.size() == chain.size() else PackedStringArray()
+
+## Returns every leg rig name across both sides that maps to a defined bone.
+func get_all_leg_rigs() -> PackedStringArray:
+	var out := _filter_present(left_leg_chain)
+	out.append_array(_filter_present(right_leg_chain))
+	return out
+
+## True if [param rig_name] belongs to either leg chain.
+func is_leg_rig(rig_name: String) -> bool:
+	return rig_name in left_leg_chain or rig_name in right_leg_chain
+
+## Returns "L"/"R" if [param rig_name] is in a leg chain, else "".
+func get_leg_side(rig_name: String) -> String:
+	if rig_name in left_leg_chain:
+		return "L"
+	if rig_name in right_leg_chain:
+		return "R"
+	return ""
+
+## Returns the skeleton bone name of the root body, used as the partial-ragdoll
+## recursion guard. Uses the explicit [member root_bone] if set, otherwise derives
+## it from [member root_rig]'s BoneDefinition.
+func get_root_skeleton_bone() -> String:
+	if root_bone != "":
+		return root_bone
+	for bone_def: BoneDefinition in bones:
+		if bone_def.rig_name == root_rig:
+			return bone_def.skeleton_bone
+	return ""
+
+
+func _has_rig(rig_name: String) -> bool:
+	if rig_name == "":
+		return false
+	for bone_def: BoneDefinition in bones:
+		if bone_def.rig_name == rig_name:
+			return true
+	return false
+
+
+func _filter_present(names: PackedStringArray) -> PackedStringArray:
+	var defined := {}
+	for bone_def: BoneDefinition in bones:
+		defined[bone_def.rig_name] = true
+	var out := PackedStringArray()
+	for n: String in names:
+		if defined.has(n):
+			out.append(n)
+	return out
 
 
 ## Creates a fully populated profile for Mixamo-compatible humanoid skeletons.
 static func create_mixamo_default() -> RagdollProfile:
 	var profile := RagdollProfile.new()
-	profile.root_bone = "mixamorig_Hips"
+	# root_bone derives from root_rig ("Hips" → "mixamorig_Hips") via get_root_skeleton_bone().
 
 	# --- Bone definitions ---
 	var bone_data: Array[Array] = [
@@ -134,11 +234,28 @@ func validate_against_skeleton(skeleton: Skeleton3D) -> PackedStringArray:
 		if joint_def.child_rig not in rig_names:
 			warnings.append("Joint child '%s' is not a defined rig bone" % joint_def.child_rig)
 
-	# Foot IK requires specific bones
-	var ik_bones := ["Foot_L", "Foot_R", "UpperLeg_L", "UpperLeg_R", "LowerLeg_L", "LowerLeg_R"]
-	for ik_bone: String in ik_bones:
-		if ik_bone not in rig_names:
-			warnings.append("Foot IK requires '%s' but it is not defined" % ik_bone)
+	# Semantic roles must reference defined rig bones
+	var single_roles := {"root_rig": root_rig, "chest_rig": chest_rig, "head_rig": head_rig}
+	for role_name: String in single_roles:
+		var rig: String = single_roles[role_name]
+		if rig != "" and rig not in rig_names:
+			warnings.append("Role '%s' references '%s' which is not a defined rig bone" % [role_name, rig])
+	var list_roles := {
+		"torso_rigs": torso_rigs, "foot_rigs": foot_rigs,
+		"left_leg_chain": left_leg_chain, "right_leg_chain": right_leg_chain,
+	}
+	for role_name: String in list_roles:
+		for rig: String in list_roles[role_name]:
+			if rig not in rig_names:
+				warnings.append("Role '%s' lists '%s' which is not a defined rig bone" % [role_name, rig])
+
+	# Foot IK requires two feet and a complete leg chain per side (role-based)
+	if get_foot_rigs().size() < 2:
+		warnings.append("Foot IK requires two foot bodies (foot_rigs role)")
+	for side: String in ["L", "R"]:
+		if get_leg_chain(side).is_empty():
+			warnings.append("Foot IK requires a complete %s leg chain (%s_leg_chain role)" % [
+				side, "left" if side == "L" else "right"])
 
 	for entry: IntermediateBoneEntry in intermediate_bones:
 		if skeleton.find_bone(entry.skeleton_bone) < 0:

--- a/addons/kickback/skeleton_detector.gd
+++ b/addons/kickback/skeleton_detector.gd
@@ -268,37 +268,21 @@ static func populate_physical_bones(
 	bone_mapping: Dictionary,
 	owner: Node
 ) -> void:
-	for slot: String in bone_mapping:
-		var skel_bone: String = bone_mapping[slot]
-		var bone_idx := skeleton.find_bone(skel_bone)
-		if bone_idx < 0:
+	# Reuse the active-rig pipeline so partial-ragdoll shapes scale to the character
+	# (instead of fixed 0.15m boxes / 0.05m capsules) and stay the single source of truth.
+	var profile := create_profile_from_skeleton(skeleton, bone_mapping)
+	for bone_def: BoneDefinition in profile.bones:
+		if skeleton.find_bone(bone_def.skeleton_bone) < 0:
 			continue
 
 		var pb := PhysicalBone3D.new()
-		pb.name = "PhysicalBone_%s" % slot
-		pb.bone_name = skel_bone
-		pb.mass = MASS_TABLE.get(slot, 5.0)
-		pb.collision_layer = 16  # Layer 5 (bit 4) — partial ragdoll bones
-		pb.collision_mask = 18   # Layers 2 + 5 (environment + other partial bones)
+		pb.name = "PhysicalBone_%s" % bone_def.rig_name
+		pb.bone_name = bone_def.skeleton_bone
+		pb.mass = bone_def.mass
+		pb.collision_layer = KickbackLayers.PARTIAL_RAGDOLL_LAYER
+		pb.collision_mask = KickbackLayers.ENVIRONMENT_LAYER | KickbackLayers.PARTIAL_RAGDOLL_LAYER
 
-		# Add collision shape
-		var col := CollisionShape3D.new()
-		var shape_type: String = SHAPE_TABLE.get(slot, "box")
-		match shape_type:
-			"box":
-				var box := BoxShape3D.new()
-				box.size = Vector3(0.15, 0.15, 0.15)
-				col.shape = box
-			"capsule":
-				var capsule := CapsuleShape3D.new()
-				capsule.radius = 0.05
-				capsule.height = 0.2
-				col.shape = capsule
-			"sphere":
-				var sphere := SphereShape3D.new()
-				sphere.radius = 0.1
-				col.shape = sphere
-
+		var col := create_collision_shape(bone_def)
 		pb.add_child(col)
 		col.owner = owner
 		simulator.add_child(pb)

--- a/addons/kickback/strength_debug_hud.gd
+++ b/addons/kickback/strength_debug_hud.gd
@@ -222,7 +222,7 @@ func _draw_skeleton_wireframe(builder: PhysicsRigBuilder, spring: SpringResolver
 
 
 func _draw_state_label(bodies: Dictionary, ctrl: ActiveRagdollController, camera: Camera3D, cam_pos: Vector3) -> void:
-	var head_body: RigidBody3D = bodies.get("Head")
+	var head_body: RigidBody3D = bodies.get(ctrl.get_head_rig())
 	if not head_body:
 		return
 	var head_pos := head_body.global_position
@@ -239,7 +239,7 @@ func _draw_state_label(bodies: Dictionary, ctrl: ActiveRagdollController, camera
 
 
 func _draw_status_panel(bodies: Dictionary, spring: SpringResolver, ctrl: ActiveRagdollController, camera: Camera3D, cam_pos: Vector3) -> void:
-	var hips_body: RigidBody3D = bodies.get("Hips")
+	var hips_body: RigidBody3D = bodies.get(ctrl.get_root_rig())
 	if not hips_body:
 		return
 	var hips_pos := hips_body.global_position
@@ -322,13 +322,19 @@ func _draw_status_panel(bodies: Dictionary, spring: SpringResolver, ctrl: Active
 
 
 func _draw_com_and_support(bodies: Dictionary, ctrl: ActiveRagdollController, camera: Camera3D, cam_pos: Vector3) -> void:
-	var foot_l: RigidBody3D = bodies.get("Foot_L")
-	var foot_r: RigidBody3D = bodies.get("Foot_R")
-	if not foot_l or not foot_r:
+	if not ctrl:
+		return
+	# Resolve feet via roles (CoM gizmo needs ≥1; the support quad needs 2).
+	var feet: Array[RigidBody3D] = []
+	for foot_rig: String in ctrl.get_foot_rigs():
+		var fb: RigidBody3D = bodies.get(foot_rig)
+		if fb:
+			feet.append(fb)
+	if feet.is_empty():
 		return
 
 	# Get full balance state from controller
-	var balance_state: Dictionary = ctrl.get_balance_state() if ctrl else {}
+	var balance_state: Dictionary = ctrl.get_balance_state()
 	var com: Vector3 = balance_state.get("com", Vector3.ZERO)
 	var support_center: Vector3 = balance_state.get("support_center", Vector3.ZERO)
 	var balance: float = balance_state.get("balance_ratio", 0.0)
@@ -342,23 +348,24 @@ func _draw_com_and_support(bodies: Dictionary, ctrl: ActiveRagdollController, ca
 		return
 	var alpha := _distance_alpha(mid_dist)
 
-	# Support polygon — filled quad between feet
-	var fl_pos := foot_l.global_position
-	var fr_pos := foot_r.global_position
-	var foot_fwd := (fl_pos - fr_pos).cross(Vector3.UP).normalized() * 0.1
-	if not camera.is_position_behind(fl_pos) and not camera.is_position_behind(fr_pos):
-		var fl_screen := camera.unproject_position(fl_pos)
-		var fr_screen := camera.unproject_position(fr_pos)
-		var fl_fwd_screen := camera.unproject_position(fl_pos + foot_fwd)
-		var fr_fwd_screen := camera.unproject_position(fr_pos + foot_fwd)
-		var fl_back_screen := camera.unproject_position(fl_pos - foot_fwd)
-		var fr_back_screen := camera.unproject_position(fr_pos - foot_fwd)
-		# Filled support area
-		var support_poly := PackedVector2Array([fl_fwd_screen, fr_fwd_screen, fr_back_screen, fl_back_screen])
-		draw_colored_polygon(support_poly, Color(SUPPORT_COLOR.r, SUPPORT_COLOR.g, SUPPORT_COLOR.b, 0.15 * alpha))
-		draw_polyline(support_poly, Color(SUPPORT_COLOR.r, SUPPORT_COLOR.g, SUPPORT_COLOR.b, SUPPORT_COLOR.a * alpha), 2.0)
-		# Close the polyline
-		draw_line(fl_back_screen, fl_fwd_screen, Color(SUPPORT_COLOR.r, SUPPORT_COLOR.g, SUPPORT_COLOR.b, SUPPORT_COLOR.a * alpha), 2.0)
+	# Support polygon — filled quad between the first two feet
+	if feet.size() >= 2:
+		var fl_pos := feet[0].global_position
+		var fr_pos := feet[1].global_position
+		var foot_fwd := (fl_pos - fr_pos).cross(Vector3.UP).normalized() * 0.1
+		if not camera.is_position_behind(fl_pos) and not camera.is_position_behind(fr_pos):
+			var fl_screen := camera.unproject_position(fl_pos)
+			var fr_screen := camera.unproject_position(fr_pos)
+			var fl_fwd_screen := camera.unproject_position(fl_pos + foot_fwd)
+			var fr_fwd_screen := camera.unproject_position(fr_pos + foot_fwd)
+			var fl_back_screen := camera.unproject_position(fl_pos - foot_fwd)
+			var fr_back_screen := camera.unproject_position(fr_pos - foot_fwd)
+			# Filled support area
+			var support_poly := PackedVector2Array([fl_fwd_screen, fr_fwd_screen, fr_back_screen, fl_back_screen])
+			draw_colored_polygon(support_poly, Color(SUPPORT_COLOR.r, SUPPORT_COLOR.g, SUPPORT_COLOR.b, 0.15 * alpha))
+			draw_polyline(support_poly, Color(SUPPORT_COLOR.r, SUPPORT_COLOR.g, SUPPORT_COLOR.b, SUPPORT_COLOR.a * alpha), 2.0)
+			# Close the polyline
+			draw_line(fl_back_screen, fl_fwd_screen, Color(SUPPORT_COLOR.r, SUPPORT_COLOR.g, SUPPORT_COLOR.b, SUPPORT_COLOR.a * alpha), 2.0)
 
 	# CoM marker — diamond shape, colored by balance
 	if not camera.is_position_behind(com):

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -495,6 +495,36 @@ func classify_region(bone_name: StringName) -> StringName:
     return &"core"  # Default
 ```
 
+## Semantic roles (custom rigs)
+
+The controller, foot IK solver, and debug HUD never hardcode bone names. They ask
+`RagdollProfile` which rig bodies play each role, via accessors that default to the
+canonical convention (`Hips`, `Chest`, `Head`, `Foot_L/R`, `UpperLeg_*`…):
+
+| Role field (export)             | Accessor                  | Used for |
+|---------------------------------|---------------------------|----------|
+| `root_rig` (`"Hips"`)           | `get_root_rig()`          | CoM base, root motion, sway anchor |
+| `chest_rig` (`"Chest"`)         | `get_chest_rig()`         | head-whip, recovery orientation |
+| `head_rig` (`"Head"`)           | `get_head_rig()`          | head-whip, state gizmo |
+| `torso_rigs`                    | `get_torso_rigs()`        | torso bend, sway falloff |
+| `foot_rigs`                     | `get_foot_rigs()`         | balance support polygon, foot IK, CoM gizmo |
+| `left_leg_chain`/`right_leg_chain` | `get_leg_chain("L"/"R")` | two-bone foot IK (hip→knee→foot) |
+
+A profile that follows the convention needs **zero** configuration. For a non-Mixamo
+rig with different rig names, override the role fields to match:
+
+```gdscript
+profile.root_rig = "pelvis"
+profile.foot_rigs = PackedStringArray(["l_ankle", "r_ankle"])
+profile.left_leg_chain = PackedStringArray(["l_thigh", "l_shin", "l_ankle"])
+profile.right_leg_chain = PackedStringArray(["r_thigh", "r_shin", "r_ankle"])
+```
+
+List accessors filter out names that don't map to a defined bone, so a missing body
+degrades gracefully instead of resolving to a null lookup. `root_bone` (the partial-ragdoll
+recursion guard) derives from `root_rig` when left empty — see `get_root_skeleton_bone()`.
+Run `validate_against_skeleton()` to flag role names that don't reference a defined bone.
+
 ## Animation requirements
 
 ### Minimum set (Step 0-2)

--- a/test/test_ragdoll_profile_roles.gd
+++ b/test/test_ragdoll_profile_roles.gd
@@ -1,0 +1,83 @@
+## Tests for RagdollProfile semantic role accessors — the API the controller,
+## foot IK solver, and debug HUD use instead of hardcoded bone-name literals.
+extends GutTest
+
+
+func _profile_with_rigs(rig_names: Array) -> RagdollProfile:
+	var p := RagdollProfile.new()
+	for rn: String in rig_names:
+		var bd := BoneDefinition.new()
+		bd.rig_name = rn
+		bd.skeleton_bone = "sk_" + rn
+		p.bones.append(bd)
+	return p
+
+
+# ── Convention defaults (Mixamo profile) ────────────────────────────────────
+
+func test_default_profile_roles():
+	var p := RagdollProfile.create_mixamo_default()
+	assert_eq(p.get_root_rig(), "Hips")
+	assert_eq(p.get_chest_rig(), "Chest")
+	assert_eq(p.get_head_rig(), "Head")
+	assert_eq(p.get_foot_rigs(), PackedStringArray(["Foot_L", "Foot_R"]))
+	assert_eq(p.get_torso_rigs(), PackedStringArray(["Hips", "Spine", "Chest"]))
+	assert_eq(p.get_leg_chain("L"), PackedStringArray(["UpperLeg_L", "LowerLeg_L", "Foot_L"]))
+	assert_eq(p.get_leg_chain("R"), PackedStringArray(["UpperLeg_R", "LowerLeg_R", "Foot_R"]))
+	assert_eq(p.get_all_leg_rigs().size(), 6)
+
+
+func test_leg_membership_and_side():
+	var p := RagdollProfile.create_mixamo_default()
+	assert_true(p.is_leg_rig("Foot_L"))
+	assert_true(p.is_leg_rig("UpperLeg_R"))
+	assert_false(p.is_leg_rig("Head"))
+	assert_eq(p.get_leg_side("Foot_L"), "L")
+	assert_eq(p.get_leg_side("LowerLeg_R"), "R")
+	assert_eq(p.get_leg_side("Head"), "")
+
+
+# ── Root skeleton bone derivation (replaces hardcoded "mixamorig_Hips") ──────
+
+func test_root_skeleton_bone_derived():
+	var p := RagdollProfile.create_mixamo_default()
+	assert_eq(p.root_bone, "", "root_bone is no longer a hardcoded default")
+	assert_eq(p.get_root_skeleton_bone(), "mixamorig_Hips", "derives from root_rig's bone")
+
+
+func test_root_skeleton_bone_explicit_override():
+	var p := RagdollProfile.create_mixamo_default()
+	p.root_bone = "custom_pelvis"
+	assert_eq(p.get_root_skeleton_bone(), "custom_pelvis")
+
+
+# ── Robustness: missing bones are filtered, not returned as dead names ───────
+
+func test_roles_filter_missing_bones():
+	# Only the left foot exists → get_foot_rigs() drops the missing right foot.
+	var p := _profile_with_rigs(["Hips", "Foot_L"])
+	assert_eq(p.get_foot_rigs(), PackedStringArray(["Foot_L"]))
+	# Incomplete leg chains → empty (foot IK needs all three links).
+	assert_eq(p.get_leg_chain("L"), PackedStringArray())
+	assert_eq(p.get_leg_chain("R"), PackedStringArray())
+
+
+func test_missing_root_returns_empty():
+	var p := _profile_with_rigs(["Spine", "Chest"])  # no root bone defined
+	assert_eq(p.get_root_rig(), "")
+	assert_eq(p.get_root_skeleton_bone(), "")
+
+
+# ── Custom (non-Mixamo) rig: roles overridden to match the rig's own names ───
+
+func test_custom_rig_overrides():
+	var p := _profile_with_rigs(["pelvis", "l_thigh", "l_shin", "l_ankle"])
+	p.root_rig = "pelvis"
+	p.foot_rigs = PackedStringArray(["l_ankle"])
+	p.left_leg_chain = PackedStringArray(["l_thigh", "l_shin", "l_ankle"])
+	assert_eq(p.get_root_rig(), "pelvis")
+	assert_eq(p.get_foot_rigs(), PackedStringArray(["l_ankle"]))
+	assert_eq(p.get_leg_chain("L"), PackedStringArray(["l_thigh", "l_shin", "l_ankle"]))
+	assert_true(p.is_leg_rig("l_shin"))
+	assert_eq(p.get_leg_side("l_ankle"), "L")
+	assert_eq(p.get_root_skeleton_bone(), "sk_pelvis", "derives skeleton bone from custom root")

--- a/test/test_ragdoll_profile_roles.gd.uid
+++ b/test/test_ragdoll_profile_roles.gd.uid
@@ -1,0 +1,1 @@
+uid://cdfg7a1f5in7f

--- a/test/test_resources.gd
+++ b/test/test_resources.gd
@@ -59,7 +59,7 @@ func test_mixamo_profile_structure():
 	assert_not_null(profile)
 	assert_eq(profile.bones.size(), 16, "Should have 16 bones")
 	assert_eq(profile.joints.size(), 15, "Should have 15 joints")
-	assert_eq(profile.root_bone, "mixamorig_Hips")
+	assert_eq(profile.get_root_skeleton_bone(), "mixamorig_Hips")
 	assert_true(profile.intermediate_bones.size() > 0)
 
 


### PR DESCRIPTION
## Summary

Workstream 2 of the 0.3.x professionalization: **de-hardcoding / generality**. The active controller, foot IK solver, and debug HUD no longer assume Mixamo bone-name literals — they resolve bones through new **semantic role accessors** on `RagdollProfile`. This completes the multi-rig balance/IK fix that PR #60's `has_support` guard only made *safe*.

API shape chosen with @blugart-dev: **role fields on `RagdollProfile`** (overridable, default to the convention, present-filtered).

## What changed

### `RagdollProfile` — semantic roles (new public API)
Overridable export fields (default to the Mixamo convention) + accessors:
`root_rig` / `chest_rig` / `head_rig` / `torso_rigs` / `foot_rigs` / `left_leg_chain` / `right_leg_chain` →
`get_root_rig()`, `get_chest_rig()`, `get_head_rig()`, `get_torso_rigs()`, `get_foot_rigs()`, `get_leg_chain("L"/"R")`, `get_all_leg_rigs()`, `is_leg_rig()`, `get_leg_side()`, `get_root_skeleton_bone()`.
- List accessors **filter out names that don't map to a defined bone**, so a missing body degrades gracefully instead of resolving to a null lookup.
- `validate_against_skeleton()` now flags role names that don't reference a defined rig bone.

### Consumers de-hardcoded (the three files the task named)
- **`active_ragdoll_controller`** — caches resolved roles at `configure`/`_ready`; all `bodies.get("Hips"/"Foot_L"/"Head"/"Chest"/"Spine")` and the leg-prefix check now go through roles. `_compute_balance_state` **generalizes to any number of feet** (support centre = mean foot position; radius = furthest foot from centre — identical to the old half-spread for 2 feet). Sway/torso-bend/brace-side preserve exact standard-rig behaviour. Exposes `get_root_rig()/get_head_rig()/get_foot_rigs()` for the HUD.
- **`foot_ik_solver`** — leg chains, feet, and root come from the profile (threaded through `initialize`); IK stays unavailable if a chain is incomplete (unchanged contract).
- **`strength_debug_hud`** — Head/Hips/feet gizmos use the controller's role getters; support quad guards on ≥2 feet.

### Collision layers
- New **`KickbackLayers`** (`class_name`) with named constants — active ragdoll = UI layer 4, partial = UI layer 5. `KickbackRaycast` and `SkeletonDetector` use them instead of `8` / `16` / `18` / `24`.

### `root_bone` inconsistency fixed
- Default `"mixamorig_Hips"` → `""`; derives from `root_rig` via `get_root_skeleton_bone()`. The partial-ragdoll recursion guard uses it. So non-Mixamo rigs get the correct guard instead of a wrong Mixamo literal.

### Partial-ragdoll shapes scale
- `SkeletonDetector.populate_physical_bones` reuses the active-rig shape pipeline (`create_profile_from_skeleton` + `create_collision_shape`) instead of fixed 0.15 m boxes / 0.05 m capsules.

### Docs / tests
- `docs/REFERENCE.md`: a "Semantic roles (custom rigs)" section with the override workflow.
- New `test/test_ragdoll_profile_roles.gd` — 7 tests incl. a non-convention custom rig, present-filtering, and `root_bone` derivation.

The data tables in `skeleton_detector` / `ragdoll_profile` / `ragdoll_tuning` keep their literals — they *define* the convention.

## Validation
- Headless `--import`: exit 0, no errors.
- GUT suite: **83/83** (76 prior + 7 new).
- Headless 150-frame runs of `tuning_playground`, `foot_ik_demo`, `demo` (active + partial), `euphoria_showcase`: exit 0, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)