### PR TITLE
0.3.x tests: first runtime/physics smoke coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,16 @@
 - **`KickbackLayers`** — named collision-layer constants (active ragdoll = UI layer 4,
   partial ragdoll = UI layer 5) replacing magic numbers in `KickbackRaycast` and
   `SkeletonDetector`.
+- **Runtime / physics smoke tests** — the first automated coverage of the physics runtime
+  (previously 0 %). The GUT suite now builds a real rig in a headless `SceneTree` — a
+  synthetic Mixamo-named skeleton wired to `PhysicsRigBuilder` + `SpringResolver` +
+  `PhysicsRigSync` + `ActiveRagdollController` via `KickbackCharacter` — steps Jolt physics,
+  and asserts rig construction (16 bodies / 15 joints, bodies snapped to bone globals),
+  spring tracking against gravity, `apply_hit` strength reduction, full ragdoll → recovery,
+  stagger and persistent transitions, physics→skeleton sync, and the real `FootIKSolver`
+  planting feet over ground. `test_state_machine.gd` and `test_foot_ik.gd` were refactored
+  to drive the real controller/solver rather than re-implement their formulas. Shared
+  builder: `test/helpers/rig_harness.gd`. Suite is now 84 tests.
 
 ### Fixed
 - **Multi-rig safety** — balance-driven stagger/ragdoll no longer silently disables on

--- a/test/helpers/rig_harness.gd
+++ b/test/helpers/rig_harness.gd
@@ -1,0 +1,183 @@
+extends Node3D
+## Runtime test harness for Kickback's physics smoke tests.
+##
+## Builds a synthetic Mixamo-named humanoid [Skeleton3D] entirely in code (no
+## imported asset dependency) and assembles the REAL Kickback active-ragdoll node
+## graph around it — [KickbackCharacter] + [PhysicsRigBuilder] + [PhysicsRigSync]
+## + [SpringResolver] + [ActiveRagdollController], wired exactly as the setup tool
+## wires a live character. A layer-1 ground [StaticBody3D] is added so the ragdoll
+## can land and foot-IK raycasts have something to hit.
+##
+## This is NOT a test script (it does not extend GutTest and lives under helpers/
+## without the "test_" prefix, so GUT never collects it). Test scripts preload it,
+## add it to the tree, call [method setup], then await [signal
+## KickbackCharacter.setup_complete] before stepping physics.
+
+## Bone table: [name, parent_name, local_position]. Parents precede children.
+## Identity bases throughout — a plain standing pose is enough to exercise the
+## spring/ragdoll/IK math, which is orientation-agnostic. Hips at 0.9 m, feet at
+## ~0.03 m above the origin (the character root), legs 0.42 m + 0.40 m long.
+const _BONES: Array = [
+	["mixamorig_Hips", "", Vector3(0.0, 0.9, 0.0)],
+	["mixamorig_Spine", "mixamorig_Hips", Vector3(0.0, 0.12, 0.0)],
+	["mixamorig_Spine1", "mixamorig_Spine", Vector3(0.0, 0.12, 0.0)],
+	["mixamorig_Spine2", "mixamorig_Spine1", Vector3(0.0, 0.12, 0.0)],
+	["mixamorig_Neck", "mixamorig_Spine2", Vector3(0.0, 0.12, 0.0)],
+	["mixamorig_Head", "mixamorig_Neck", Vector3(0.0, 0.10, 0.0)],
+	["mixamorig_HeadTop_End", "mixamorig_Head", Vector3(0.0, 0.18, 0.0)],
+	["mixamorig_LeftArm", "mixamorig_Spine2", Vector3(0.18, 0.10, 0.0)],
+	["mixamorig_LeftForeArm", "mixamorig_LeftArm", Vector3(0.28, 0.0, 0.0)],
+	["mixamorig_LeftHand", "mixamorig_LeftForeArm", Vector3(0.25, 0.0, 0.0)],
+	["mixamorig_RightArm", "mixamorig_Spine2", Vector3(-0.18, 0.10, 0.0)],
+	["mixamorig_RightForeArm", "mixamorig_RightArm", Vector3(-0.28, 0.0, 0.0)],
+	["mixamorig_RightHand", "mixamorig_RightForeArm", Vector3(-0.25, 0.0, 0.0)],
+	["mixamorig_LeftUpLeg", "mixamorig_Hips", Vector3(0.10, -0.05, 0.0)],
+	["mixamorig_LeftLeg", "mixamorig_LeftUpLeg", Vector3(0.0, -0.42, 0.0)],
+	["mixamorig_LeftFoot", "mixamorig_LeftLeg", Vector3(0.0, -0.40, 0.0)],
+	["mixamorig_LeftToeBase", "mixamorig_LeftFoot", Vector3(0.0, -0.05, 0.12)],
+	["mixamorig_RightUpLeg", "mixamorig_Hips", Vector3(-0.10, -0.05, 0.0)],
+	["mixamorig_RightLeg", "mixamorig_RightUpLeg", Vector3(0.0, -0.42, 0.0)],
+	["mixamorig_RightFoot", "mixamorig_RightLeg", Vector3(0.0, -0.40, 0.0)],
+	["mixamorig_RightToeBase", "mixamorig_RightFoot", Vector3(0.0, -0.05, 0.12)],
+]
+
+## Rig names of the 16 physics bodies the Mixamo profile builds (for assertions).
+const RIG_NAMES: Array = [
+	"Hips", "Spine", "Chest", "Head",
+	"UpperArm_L", "LowerArm_L", "Hand_L",
+	"UpperArm_R", "LowerArm_R", "Hand_R",
+	"UpperLeg_L", "LowerLeg_L", "Foot_L",
+	"UpperLeg_R", "LowerLeg_R", "Foot_R",
+]
+
+var skeleton: Skeleton3D
+var character: KickbackCharacter
+var rig_builder: PhysicsRigBuilder
+var rig_sync: PhysicsRigSync
+var spring: SpringResolver
+var controller: ActiveRagdollController
+var ground: StaticBody3D
+var tuning: RagdollTuning
+var profile: RagdollProfile
+
+
+## Builds the synthetic skeleton, optional ground, and the full Kickback graph.
+## Call after the harness is already inside the SceneTree. Pass a [RagdollTuning]
+## and/or [RagdollProfile] to override the Mixamo defaults. After this returns,
+## await [member character]'s setup_complete signal before asserting.
+func setup(p_tuning: RagdollTuning = null, p_profile: RagdollProfile = null, with_ground: bool = true) -> void:
+	tuning = p_tuning if p_tuning else RagdollTuning.create_default()
+	profile = p_profile if p_profile else RagdollProfile.create_mixamo_default()
+
+	if with_ground:
+		ground = _build_ground()
+		add_child(ground)
+
+	skeleton = _build_skeleton()
+	add_child(skeleton)
+
+	# Sibling controllers, pre-configured BEFORE entering the tree so their
+	# _ready (which builds the rig / adjacency from the profile) sees the right
+	# config rather than falling back to defaults. KickbackCharacter re-applies
+	# the same config in its own _ready — idempotent.
+	rig_builder = PhysicsRigBuilder.new()
+	rig_builder.name = "PhysicsRigBuilder"
+	rig_builder.skeleton_path = NodePath("../Skeleton3D")
+	rig_builder.configure(profile, tuning)
+	add_child(rig_builder)
+
+	rig_sync = PhysicsRigSync.new()
+	rig_sync.name = "PhysicsRigSync"
+	rig_sync.skeleton_path = NodePath("../Skeleton3D")
+	rig_sync.rig_builder_path = NodePath("../PhysicsRigBuilder")
+	rig_sync.configure(profile)
+	add_child(rig_sync)
+
+	spring = SpringResolver.new()
+	spring.name = "SpringResolver"
+	spring.skeleton_path = NodePath("../Skeleton3D")
+	spring.rig_builder_path = NodePath("../PhysicsRigBuilder")
+	spring.configure(tuning)
+	add_child(spring)
+
+	controller = ActiveRagdollController.new()
+	controller.name = "ActiveRagdollController"
+	controller.spring_resolver_path = NodePath("../SpringResolver")
+	controller.rig_builder_path = NodePath("../PhysicsRigBuilder")
+	controller.rig_sync_path = NodePath("../PhysicsRigSync")
+	controller.character_root_path = NodePath("..")
+	controller.configure(profile, tuning)
+	add_child(controller)
+
+	# KickbackCharacter LAST so its sibling scan finds all four controllers.
+	character = KickbackCharacter.new()
+	character.name = "KickbackCharacter"
+	character.skeleton_path = NodePath("../Skeleton3D")
+	character.character_root_path = NodePath("..")
+	character.ragdoll_profile = profile
+	character.ragdoll_tuning = tuning
+	add_child(character)
+
+
+## Awaits Kickback setup with a frame budget. Returns true once the character is
+## fully initialized, false if it never completes within [param max_frames].
+func await_ready(max_frames: int = 30) -> bool:
+	var frames := 0
+	while not character.is_setup_complete() and frames < max_frames:
+		await get_tree().process_frame
+		frames += 1
+	return character.is_setup_complete()
+
+
+func get_body(rig_name: String) -> RigidBody3D:
+	return rig_builder.get_bodies().get(rig_name)
+
+
+func bone_idx(skeleton_bone: String) -> int:
+	return skeleton.find_bone(skeleton_bone)
+
+
+## World-space origin the skeleton currently reports for a bone (override layer
+## included — this is what PhysicsRigSync writes the physics pose into).
+func skeleton_bone_world_origin(skeleton_bone: String) -> Vector3:
+	var idx := skeleton.find_bone(skeleton_bone)
+	if idx < 0:
+		return Vector3.ZERO
+	return (skeleton.global_transform * skeleton.get_bone_global_pose(idx)).origin
+
+
+func _build_skeleton() -> Skeleton3D:
+	var skel := Skeleton3D.new()
+	skel.name = "Skeleton3D"
+	var name_to_idx: Dictionary = {}
+	for entry: Array in _BONES:
+		var bone_name: String = entry[0]
+		var parent_name: String = entry[1]
+		var pos: Vector3 = entry[2]
+		var idx := skel.add_bone(bone_name)
+		name_to_idx[bone_name] = idx
+		if parent_name != "":
+			skel.set_bone_parent(idx, name_to_idx[parent_name])
+		var rest := Transform3D(Basis(), pos)
+		skel.set_bone_rest(idx, rest)
+		# Pose defaults to identity until set; copy rest into the pose so the
+		# animation target the SpringResolver reads matches the rest layout.
+		skel.set_bone_pose_position(idx, pos)
+		skel.set_bone_pose_rotation(idx, Quaternion.IDENTITY)
+		skel.set_bone_pose_scale(idx, Vector3.ONE)
+	return skel
+
+
+func _build_ground() -> StaticBody3D:
+	var body := StaticBody3D.new()
+	body.name = "Ground"
+	body.collision_layer = 1  # layer 1 — matches default foot-IK + get-up ray masks
+	body.collision_mask = 0
+	var shape := CollisionShape3D.new()
+	var box := BoxShape3D.new()
+	box.size = Vector3(20.0, 0.4, 20.0)
+	shape.shape = box
+	body.add_child(shape)
+	# Top surface flush with the origin (y = 0), where the feet rest.
+	body.position = Vector3(0.0, -0.2, 0.0)
+	return body

--- a/test/helpers/rig_harness.gd.uid
+++ b/test/helpers/rig_harness.gd.uid
@@ -1,0 +1,1 @@
+uid://cx7losbfev4es

--- a/test/test_foot_ik.gd
+++ b/test/test_foot_ik.gd
@@ -1,11 +1,31 @@
 extends GutTest
 
 
-# ── FootIKSolver unit tests ────────────────────────────────────────────────
-# Tests the IK solver's math and state management without a full scene.
-# Scene-dependent features (raycasting, spring integration) require
-# integration tests in the demo scenes.
+# ── FootIKSolver tests ──────────────────────────────────────────────────────
+# Two layers:
+#   1. Lifecycle / config tests that exercise the real solver and the real
+#      RagdollTuning validation with no scene.
+#   2. Runtime tests that drive the REAL FootIKSolver — the one the
+#      ActiveRagdollController lazily creates — on a live rig standing over a
+#      ground plane (built via res://test/helpers/rig_harness.gd), replacing the
+#      old re-implemented swing/pelvis formula tests.
 
+const RigHarness := preload("res://test/helpers/rig_harness.gd")
+
+
+# Builds a rig with foot IK ENABLED over a ground plane, then steps physics so
+# the controller's lazy FootIKSolver initializes and solves a few NORMAL frames.
+func _spawn_with_foot_ik(extra_frames: int = 20):
+	var h = RigHarness.new()
+	add_child_autoqfree(h)
+	h.setup(RagdollTuning.create_default(), null, true)  # foot_ik_enabled is on by default
+	var ok: bool = await h.await_ready(40)
+	assert_true(ok, "Kickback setup completed within frame budget")
+	await wait_physics_frames(extra_frames)
+	return h
+
+
+# ── Solver lifecycle (real class, no scene) ────────────────────────────────
 
 func test_solver_creation():
 	var solver := FootIKSolver.new()
@@ -42,7 +62,7 @@ func test_stagger_lifecycle():
 	assert_false(solver._stagger_pinning)
 
 
-# ── RagdollTuning foot IK defaults ────────────────────────────────────────
+# ── RagdollTuning foot IK defaults / validation ────────────────────────────
 
 func test_default_tuning_has_foot_ik():
 	var t := RagdollTuning.create_default()
@@ -80,53 +100,37 @@ func test_tuning_warns_missing_foot_bones():
 	assert_true(warnings.size() > 0, "Should warn about missing foot IK bones")
 
 
-# ── Swing detection math ──────────────────────────────────────────────────
+# ── Real FootIKSolver on a live rig ────────────────────────────────────────
 
-func test_swing_detection_logic():
-	# Replicate the swing detection formula from FootIKSolver
-	var swing_threshold := 0.25
-	var plant_threshold := 0.17
-	var range_val := swing_threshold - plant_threshold
-
-	# Foot at root level (planted)
-	var far_planted := 0.10
-	var tw_planted := clampf(1.0 - (far_planted - plant_threshold) / range_val, 0.0, 1.0)
-	assert_almost_eq(tw_planted, 1.0, 0.01, "Foot at root should be fully planted")
-
-	# Foot at swing threshold (transitioning)
-	var far_swing := 0.25
-	var tw_swing := clampf(1.0 - (far_swing - plant_threshold) / range_val, 0.0, 1.0)
-	assert_almost_eq(tw_swing, 0.0, 0.01, "Foot at swing threshold should have zero weight")
-
-	# Foot mid-range
-	var far_mid := 0.21
-	var tw_mid := clampf(1.0 - (far_mid - plant_threshold) / range_val, 0.0, 1.0)
-	assert_true(tw_mid > 0.0 and tw_mid < 1.0, "Mid-range should be partial weight")
-
-	# Foot well above swing threshold
-	var far_high := 0.5
-	if far_high >= swing_threshold:
-		pass  # Weight stays 0 (not computed)
-	assert_true(true, "High foot skipped correctly")
+func test_controller_creates_foot_ik_solver():
+	var h = await _spawn_with_foot_ik()
+	assert_not_null(h.controller._foot_ik, "controller lazily created a FootIKSolver")
+	assert_true(h.controller._foot_ik.is_initialized(), "solver initialized against the rig")
 
 
-func test_pelvis_offset_clamping():
-	var max_drop := 0.35
-	# Both feet below animation → pelvis drops
-	var offset_l := -0.2
-	var offset_r := -0.3
-	var wl := 1.0
-	var wr := 1.0
-	var target := clampf(minf(offset_l * wl, offset_r * wr), -max_drop, 0.0)
-	assert_almost_eq(target, -0.3, 0.001, "Pelvis should drop to lowest foot")
+func test_solver_reads_leg_lengths_from_rest():
+	var h = await _spawn_with_foot_ik()
+	var solver = h.controller._foot_ik
+	assert_not_null(solver)
+	# Lengths are derived from the skeleton's rest poses (0.42 m + 0.40 m).
+	assert_almost_eq(solver._upper_leg_len, 0.42, 0.02, "upper leg length read from rest")
+	assert_almost_eq(solver._lower_leg_len, 0.40, 0.02, "lower leg length read from rest")
 
-	# Extreme drop gets clamped
-	offset_r = -0.5
-	target = clampf(minf(offset_l * wl, offset_r * wr), -max_drop, 0.0)
-	assert_almost_eq(target, -max_drop, 0.001, "Pelvis drop should clamp to max")
 
-	# Positive offset (foot above animation) → no pelvis lift
-	offset_l = 0.1
-	offset_r = 0.2
-	target = clampf(minf(offset_l * wl, offset_r * wr), -max_drop, 0.0)
-	assert_almost_eq(target, 0.0, 0.001, "Pelvis should not lift above zero")
+func test_feet_plant_over_ground():
+	# Extra frames so the exponential weight blend has time to ramp toward 1.
+	var h = await _spawn_with_foot_ik(35)
+	var solver = h.controller._foot_ik
+	assert_not_null(solver)
+	assert_gt(solver._ik_weight_l, 0.4, "left foot plants over the ground")
+	assert_gt(solver._ik_weight_r, 0.4, "right foot plants over the ground")
+	assert_true(solver.is_active(), "foot IK reports active")
+
+
+func test_pelvis_never_lifts_on_flat_ground():
+	var h = await _spawn_with_foot_ik(35)
+	var solver = h.controller._foot_ik
+	assert_not_null(solver)
+	# Feet rest on flat ground level with the root, so the pelvis must not rise.
+	assert_true(solver._pelvis_offset <= 0.001,
+		"pelvis offset never lifts above zero (got %f)" % solver._pelvis_offset)

--- a/test/test_runtime_rig.gd
+++ b/test/test_runtime_rig.gd
@@ -1,0 +1,167 @@
+extends GutTest
+
+# ── Runtime / physics smoke tests ──────────────────────────────────────────
+# Builds a REAL Kickback rig (synthetic skeleton + PhysicsRigBuilder +
+# SpringResolver + PhysicsRigSync + ActiveRagdollController, coordinated by
+# KickbackCharacter) inside the headless SceneTree, steps Jolt physics, and
+# asserts the rig builds, the springs track the animation pose, hits land, and
+# the sync writes physics back onto the skeleton. State-machine transitions
+# (ragdoll / recovery / stagger) live in test_state_machine.gd; foot IK lives in
+# test_foot_ik.gd. All three share res://test/helpers/rig_harness.gd.
+
+const RigHarness := preload("res://test/helpers/rig_harness.gd")
+
+
+func _core_tuning() -> RagdollTuning:
+	# Foot IK off so the solver's per-frame target overrides don't perturb the
+	# rest pose these tests assert against.
+	var t := RagdollTuning.create_default()
+	t.foot_ik_enabled = false
+	return t
+
+
+func _spawn(tuning: RagdollTuning = null, with_ground: bool = true):
+	var h = RigHarness.new()
+	add_child_autoqfree(h)
+	h.setup(tuning if tuning else _core_tuning(), null, with_ground)
+	var ok: bool = await h.await_ready(40)
+	assert_true(ok, "Kickback setup completed within frame budget")
+	return h
+
+
+# ── Setup / construction ────────────────────────────────────────────────────
+
+func test_setup_enters_active_mode():
+	var h = await _spawn()
+	assert_eq(h.character.get_mode(), KickbackCharacter.Mode.ACTIVE, "active ragdoll mode detected")
+	assert_eq(h.character.get_active_state(), ActiveRagdollController.State.NORMAL)
+
+
+func test_rig_builds_all_bodies():
+	var h = await _spawn()
+	var bodies: Dictionary = h.rig_builder.get_bodies()
+	assert_eq(bodies.size(), 16, "16 RigidBody3D bodies built from the Mixamo profile")
+	for rig_name: String in RigHarness.RIG_NAMES:
+		assert_true(bodies.has(rig_name), "body '%s' present" % rig_name)
+		assert_true(bodies[rig_name] is RigidBody3D, "body '%s' is a RigidBody3D" % rig_name)
+
+
+func test_rig_builds_all_joints():
+	var h = await _spawn()
+	var joints := 0
+	for child in h.rig_builder.get_children():
+		if child is Generic6DOFJoint3D:
+			joints += 1
+	assert_eq(joints, 15, "15 Generic6DOFJoint3D joints connect the 16 bodies")
+
+
+func test_bodies_snap_to_bone_globals():
+	# Groundless — this asserts the builder's placement, before any ground contact
+	# can nudge a foot off its bone.
+	var h = await _spawn(null, false)
+	# Each body should be created at its skeleton bone's world pose.
+	for pair in [["Hips", "mixamorig_Hips"], ["Head", "mixamorig_Head"], ["Foot_L", "mixamorig_LeftFoot"]]:
+		var body: RigidBody3D = h.get_body(pair[0])
+		var bone_origin: Vector3 = h.skeleton_bone_world_origin(pair[1])
+		assert_lt(body.global_position.distance_to(bone_origin), 0.06,
+			"%s body sits on its bone" % pair[0])
+
+
+func test_spring_registers_all_bones_with_base_strengths():
+	var h = await _spawn()
+	var names: PackedStringArray = h.spring.get_all_bone_names()
+	assert_eq(names.size(), 16, "spring resolver registered all 16 bodies")
+	# Base strengths come straight from the tuning strength_map.
+	assert_almost_eq(h.spring.get_base_strength("Hips"), 0.65, 0.001)
+	assert_almost_eq(h.spring.get_base_strength("Head"), 0.35, 0.001)
+	assert_almost_eq(h.spring.get_base_strength("Hand_L"), 0.25, 0.001)
+
+
+# ── Spring tracking ─────────────────────────────────────────────────────────
+
+func test_springs_hold_pose_against_gravity():
+	# Groundless: the springs alone must counter gravity — nothing holds the rig
+	# up from below.
+	var h = await _spawn(null, false)
+	var hips: RigidBody3D = h.get_body("Hips")
+	var start_y := hips.global_position.y
+	assert_almost_eq(start_y, 0.9, 0.1, "hips start near the rest height")
+
+	await wait_physics_frames(45)
+
+	# At full spring strength gravity is cancelled and the pin holds the hips up.
+	# Without working springs the body would collapse toward the ground (~0).
+	assert_gt(hips.global_position.y, 0.7, "springs hold the hips up against gravity")
+	assert_lt(hips.global_position.y, 1.1, "hips do not launch upward")
+	assert_eq(h.controller.get_state(), ActiveRagdollController.State.NORMAL, "stays NORMAL with no hits")
+	# Core orientation tracks the (upright) animation pose rather than toppling.
+	assert_gt(hips.global_transform.basis.y.dot(Vector3.UP), 0.9,
+		"hips stay upright — springs track the animation orientation")
+
+
+# ── Hit handling (apply_hit) ────────────────────────────────────────────────
+
+func test_apply_hit_reduces_bone_strength():
+	var h = await _spawn()
+	var head: RigidBody3D = h.get_body("Head")
+	var before: float = h.spring.get_bone_strength("Head")
+
+	var impact := ImpactProfile.new()
+	impact.base_impulse = 5.0
+	impact.impulse_transfer_ratio = 0.3
+	impact.ragdoll_probability = 0.0   # deterministic: never random-ragdoll
+	impact.strength_reduction = 0.5
+	impact.strength_spread = 0
+	impact.recovery_rate = 1.0
+
+	watch_signals(h.controller)
+	h.controller.apply_hit(head, Vector3.FORWARD, head.global_position, impact)
+
+	assert_lt(h.spring.get_bone_strength("Head"), before, "hit reduced the head spring strength")
+	assert_ne(h.controller.get_state(), ActiveRagdollController.State.RAGDOLL,
+		"a single weak hit with 0 ragdoll chance does not ragdoll")
+	assert_signal_emitted(h.controller, "hit_absorbed", "a sub-stagger hit emits hit_absorbed")
+
+
+# ── Skeleton sync (physics → Skeleton3D) ────────────────────────────────────
+
+func test_skeleton_sync_follows_physics_during_ragdoll():
+	var h = await _spawn()
+	var hips: RigidBody3D = h.get_body("Hips")
+	var start := hips.global_position
+
+	h.controller.trigger_ragdoll()
+	# Let the now-limp rig fall and collapse under gravity.
+	await wait_physics_frames(30)
+
+	assert_gt(start.distance_to(hips.global_position), 0.1,
+		"with springs zeroed, physics moves the hips body")
+	# PhysicsRigSync should have written that physics pose onto the skeleton.
+	var synced: Vector3 = h.skeleton_bone_world_origin("mixamorig_Hips")
+	assert_lt(synced.distance_to(hips.global_position), 0.06,
+		"skeleton hips bone follows the physics body via PhysicsRigSync")
+
+
+# ── Coordinator facade + balance ────────────────────────────────────────────
+
+func test_kickback_character_ragdoll_facade():
+	var h = await _spawn()
+	assert_false(h.character.is_ragdolled(), "starts on its feet")
+	h.character.trigger_ragdoll()
+	assert_true(h.character.is_ragdolled(), "KickbackCharacter.is_ragdolled() tracks the controller")
+	assert_eq(h.character.get_active_state(), ActiveRagdollController.State.RAGDOLL)
+
+
+func test_balance_state_reports_support_when_standing():
+	var h = await _spawn()
+	var bs: Dictionary = h.controller.get_balance_state()
+	assert_true(bs.has_support, "two foot bodies → balance has a support polygon")
+	assert_lt(float(bs.balance_ratio), 0.5, "a centered standing pose reads as roughly balanced")
+
+
+func test_anticipate_threat_emits_signal():
+	var h = await _spawn()
+	watch_signals(h.controller)
+	h.character.anticipate_threat(Vector3.FORWARD, 0.8)
+	assert_signal_emitted(h.controller, "threat_anticipated",
+		"anticipate_threat routes through to the controller signal")

--- a/test/test_runtime_rig.gd.uid
+++ b/test/test_runtime_rig.gd.uid
@@ -1,0 +1,1 @@
+uid://ddwpp25jn8rpn

--- a/test/test_state_machine.gd
+++ b/test/test_state_machine.gd
@@ -1,145 +1,102 @@
 extends GutTest
 
+# ── ActiveRagdollController state machine ──────────────────────────────────
+# Drives the REAL controller through its NORMAL → RAGDOLL → GETTING_UP → NORMAL,
+# stagger, and persistent transitions on a live physics rig (built via
+# res://test/helpers/rig_harness.gd), rather than re-implementing its formulas.
+# The remaining pure tests assert tuning/enum invariants the controller relies
+# on (threshold ordering, enum values), which are not re-implementations.
 
-func _effective_base(base: float, fatigue: float, injury: float, tuning: RagdollTuning) -> float:
-	return base * (1.0 - fatigue * tuning.fatigue_impact) * (1.0 - injury * tuning.injury_impact)
-
-
-func _streak_multiplier(streak: int, tuning: RagdollTuning) -> float:
-	return 1.0 + float(streak) * tuning.hit_streak_multiplier
-
-
-func _movement_instability(speed: float, tuning: RagdollTuning) -> float:
-	if speed < tuning.movement_instability_min_speed:
-		return 1.0
-	var ratio := clampf(
-		(speed - tuning.movement_instability_min_speed) /
-		(tuning.movement_instability_max_speed - tuning.movement_instability_min_speed),
-		0.0, 1.0)
-	return 1.0 + ratio * tuning.movement_instability_bonus
+const RigHarness := preload("res://test/helpers/rig_harness.gd")
 
 
-# ── Effective base strength formula ───────────────────────────────────────────
-
-func test_effective_base_no_debuffs():
+# Fast, deterministic tuning: short ragdoll/recovery windows keep the wall-clock
+# low, foot IK off and sway off so a balanced stance can't tip mid-test.
+func _fast_tuning() -> RagdollTuning:
 	var t := RagdollTuning.create_default()
-	assert_almost_eq(_effective_base(0.65, 0.0, 0.0, t), 0.65, 0.001)
+	t.foot_ik_enabled = false
+	t.ragdoll_force_recovery_time = 0.4
+	t.recovery_duration = 0.4
+	t.safety_timeout = 0.6
+	t.pose_blend_duration = 0.2
+	t.settle_duration = 0.15
+	t.stagger_duration = 0.3
+	t.stagger_sway_strength = 0.0
+	return t
 
 
-func test_effective_base_max_fatigue():
-	var t := RagdollTuning.create_default()
-	assert_almost_eq(_effective_base(0.65, 1.0, 0.0, t), 0.325, 0.001)
+func _spawn(tuning: RagdollTuning):
+	var h = RigHarness.new()
+	add_child_autoqfree(h)
+	h.setup(tuning, null, true)
+	var ok: bool = await h.await_ready(40)
+	assert_true(ok, "Kickback setup completed within frame budget")
+	return h
 
 
-func test_effective_base_max_injury():
-	var t := RagdollTuning.create_default()
-	assert_almost_eq(_effective_base(0.65, 0.0, 1.0, t), 0.39, 0.001)
+# ── Real state-machine transitions ──────────────────────────────────────────
+
+func test_trigger_ragdoll_zeroes_springs():
+	var h = await _spawn(_fast_tuning())
+	watch_signals(h.controller)
+	h.controller.trigger_ragdoll()
+
+	assert_eq(h.controller.get_state(), ActiveRagdollController.State.RAGDOLL)
+	assert_signal_emitted(h.controller, "ragdoll_started")
+	assert_signal_emitted(h.controller, "state_changed")
+	for rig_name: String in RigHarness.RIG_NAMES:
+		assert_almost_eq(h.spring.get_bone_strength(rig_name), 0.0, 0.001,
+			"%s spring zeroed on ragdoll" % rig_name)
 
 
-func test_effective_base_both_max():
-	var t := RagdollTuning.create_default()
-	assert_almost_eq(_effective_base(0.65, 1.0, 1.0, t), 0.195, 0.001)
+func test_ragdoll_recovers_to_normal():
+	var h = await _spawn(_fast_tuning())
+	watch_signals(h.controller)
+	h.controller.trigger_ragdoll()
+	assert_eq(h.controller.get_state(), ActiveRagdollController.State.RAGDOLL)
+
+	# Force-recovery + safety timeout guarantee the cycle completes quickly.
+	var recovered: bool = await wait_for_signal(h.controller.recovery_finished, 8.0)
+	assert_true(recovered, "recovery_finished fired within the timeout")
+	assert_eq(h.controller.get_state(), ActiveRagdollController.State.NORMAL, "returned to NORMAL")
+	assert_signal_emitted(h.controller, "recovery_started")
+	# Springs ramp back to their base strength after recovery.
+	assert_almost_eq(h.spring.get_bone_strength("Hips"), 0.65, 0.02, "hips spring restored to base")
 
 
-# ── Hit streak multiplier ────────────────────────────────────────────────────
+func test_trigger_stagger_reduces_strength_and_recovers():
+	var h = await _spawn(_fast_tuning())
+	watch_signals(h.controller)
+	h.controller.trigger_stagger(Vector3.FORWARD)
 
-func test_streak_zero():
-	var t := RagdollTuning.create_default()
-	assert_almost_eq(_streak_multiplier(0, t), 1.0, 0.001)
+	assert_eq(h.controller.get_state(), ActiveRagdollController.State.STAGGER)
+	assert_signal_emitted(h.controller, "stagger_started")
+	assert_lt(h.spring.get_bone_strength("Hips"), 0.2,
+		"stagger drops spring strength toward the floor")
 
-
-func test_streak_one():
-	var t := RagdollTuning.create_default()
-	assert_almost_eq(_streak_multiplier(1, t), 1.3, 0.001)
-
-
-func test_streak_five():
-	var t := RagdollTuning.create_default()
-	assert_almost_eq(_streak_multiplier(5, t), 2.5, 0.001)
+	var finished: bool = await wait_for_signal(h.controller.stagger_finished, 5.0)
+	assert_true(finished, "stagger auto-recovers to NORMAL")
+	assert_eq(h.controller.get_state(), ActiveRagdollController.State.NORMAL)
 
 
-# ── Movement instability ─────────────────────────────────────────────────────
+func test_persistent_holds_until_released():
+	var h = await _spawn(_fast_tuning())
+	h.controller.set_persistent(true)
+	assert_eq(h.controller.get_state(), ActiveRagdollController.State.PERSISTENT)
 
-func test_instability_below_min_speed():
-	var t := RagdollTuning.create_default()
-	assert_almost_eq(_movement_instability(0.5, t), 1.0, 0.001)
+	# Persistent ragdoll must NOT auto-recover while it is held.
+	await wait_physics_frames(20)
+	assert_eq(h.controller.get_state(), ActiveRagdollController.State.PERSISTENT,
+		"persistent ragdoll stays down")
 
-
-func test_instability_mid_speed():
-	var t := RagdollTuning.create_default()
-	assert_almost_eq(_movement_instability(3.0, t), 1.15, 0.001)
-
-
-func test_instability_max_speed():
-	var t := RagdollTuning.create_default()
-	assert_almost_eq(_movement_instability(5.0, t), 1.3, 0.001)
-
-
-func test_instability_over_max_clamped():
-	var t := RagdollTuning.create_default()
-	assert_almost_eq(_movement_instability(10.0, t), 1.3, 0.001)
+	watch_signals(h.controller)
+	h.controller.set_persistent(false)
+	var recovered: bool = await wait_for_signal(h.controller.recovery_finished, 8.0)
+	assert_true(recovered, "releasing persistent starts recovery")
+	assert_eq(h.controller.get_state(), ActiveRagdollController.State.NORMAL)
 
 
-# ── Pain thresholds ──────────────────────────────────────────────────────────
-
-func test_pain_thresholds_ordered():
-	var t := RagdollTuning.create_default()
-	assert_eq(t.pain_stagger_threshold, 0.5)
-	assert_eq(t.pain_ragdoll_threshold, 0.9)
-	assert_true(t.pain_stagger_threshold < t.pain_ragdoll_threshold)
-
-
-# ── Balance thresholds ────────────────────────────────────────────────────────
-
-func test_balance_thresholds_ordered():
-	var t := RagdollTuning.create_default()
-	assert_true(t.balance_recovery_threshold < t.balance_stagger_threshold)
-	assert_true(t.balance_stagger_threshold < t.balance_ragdoll_threshold)
-
-
-# ── Fatigue accumulation ──────────────────────────────────────────────────────
-
-func test_single_hit_fatigue():
-	var t := RagdollTuning.create_default()
-	var fatigue := clampf(0.0 + 0.85 * t.fatigue_gain, 0.0, 1.0)
-	assert_almost_eq(fatigue, 0.1275, 0.001)
-
-
-func test_fatigue_clamped_after_many_hits():
-	var t := RagdollTuning.create_default()
-	var fatigue := 0.0
-	for i in 10:
-		fatigue = clampf(fatigue + 0.85 * t.fatigue_gain, 0.0, 1.0)
-	assert_true(fatigue <= 1.0)
-
-
-# ── Stagger floor ────────────────────────────────────────────────────────────
-
-func test_hips_floor_value():
-	var t := RagdollTuning.create_default()
-	assert_almost_eq(0.65 * t.stagger_strength_floor, 0.065, 0.001)
-
-
-func test_fatigued_floor():
-	var t := RagdollTuning.create_default()
-	var eff := 0.65 * (1.0 - 1.0 * t.fatigue_impact)
-	assert_almost_eq(eff * t.stagger_strength_floor, 0.0325, 0.001)
-
-
-# ── Injury pin impact ────────────────────────────────────────────────────────
-
-func test_injured_pin():
-	var t := RagdollTuning.create_default()
-	var pin := 0.85 * (1.0 - 0.5 * t.injury_pin_impact)
-	assert_almost_eq(pin, 0.5525, 0.001)
-
-
-func test_injury_threshold():
-	var t := RagdollTuning.create_default()
-	assert_eq(t.injury_threshold, 0.3)
-
-
-# ── State enum values ─────────────────────────────────────────────────────────
+# ── Enum / tuning invariants (not re-implemented formulas) ──────────────────
 
 func test_state_enum():
 	assert_eq(ActiveRagdollController.State.NORMAL, 0)
@@ -147,3 +104,22 @@ func test_state_enum():
 	assert_eq(ActiveRagdollController.State.RAGDOLL, 2)
 	assert_eq(ActiveRagdollController.State.GETTING_UP, 3)
 	assert_eq(ActiveRagdollController.State.PERSISTENT, 4)
+
+
+func test_pain_thresholds_ordered():
+	var t := RagdollTuning.create_default()
+	assert_eq(t.pain_stagger_threshold, 0.5)
+	assert_eq(t.pain_ragdoll_threshold, 0.9)
+	assert_true(t.pain_stagger_threshold < t.pain_ragdoll_threshold,
+		"pain must cross stagger before ragdoll")
+
+
+func test_balance_thresholds_ordered():
+	var t := RagdollTuning.create_default()
+	assert_true(t.balance_recovery_threshold < t.balance_stagger_threshold)
+	assert_true(t.balance_stagger_threshold < t.balance_ragdoll_threshold)
+
+
+func test_injury_threshold_default():
+	var t := RagdollTuning.create_default()
+	assert_eq(t.injury_threshold, 0.3)


### PR DESCRIPTION
## Workstream 4 — test coverage

The 83-test GUT suite was entirely pure logic/config: **~0% of the physics runtime was exercised**. This adds the first runtime/physics smoke tests — building a *real* Kickback rig in a headless `SceneTree`, stepping Jolt physics, and asserting behavior — and refactors the two formula-duplicating suites to drive the real classes instead of re-implemented math.

### Harness — `test/helpers/rig_harness.gd`
Builds a **synthetic Mixamo-named `Skeleton3D` in code** (21 bones, standing rest pose, feet ≈0.03 m above the root — no imported-asset dependency) and assembles the full Kickback graph exactly as the setup tool wires a live character: `KickbackCharacter` + `PhysicsRigBuilder` + `PhysicsRigSync` + `SpringResolver` + `ActiveRagdollController`, siblings under a Node3D character-root, pre-configured with a `RagdollProfile`/`RagdollTuning`. Optional layer-1 ground for landing + foot-IK raycasts. Not collected by GUT (no `test_` prefix, lives under `helpers/`); test scripts preload it and await `setup_complete`.

### New — `test/test_runtime_rig.gd`
- Construction: active mode detected, 16 `RigidBody3D` + 15 `Generic6DOFJoint3D`, bodies snapped to bone globals, spring bones registered at `strength_map` bases.
- Spring tracking: at full strength the springs cancel gravity and hold the hips up + upright.
- `apply_hit` reduces the hit bone's strength and emits `hit_absorbed` without ragdolling (deterministic, 0 ragdoll chance).
- Physics→skeleton sync: during ragdoll the `Skeleton3D` hips bone follows the moved physics body via `PhysicsRigSync`.
- Coordinator facade: `is_ragdolled()`, `get_balance_state().has_support`, `anticipate_threat` → signal.

### Refactor — drive the real classes
- **`test_state_machine.gd`**: dropped the re-implemented effective-base / hit-streak / movement-instability / stagger-floor formulas; drives the **real `ActiveRagdollController`** through `RAGDOLL → recovery`, stagger, and persistent transitions on a live rig (fast tuning keeps wall-clock low). Kept the enum + threshold-ordering invariants.
- **`test_foot_ik.gd`**: dropped the re-implemented swing/pelvis math; drives the **real `FootIKSolver`** (the one the controller lazily creates) over a ground plane — initializes, reads leg lengths from rest poses, feet plant (`_ik_weight` ramps), pelvis never lifts. Kept the solver-lifecycle + tuning-validation tests.

### Validation
- Clean headless `--import` (exit 0).
- **84 tests pass, verified stable across 4 consecutive headless runs** (no physics flake). Structural/foot-touching asserts run groundless so ground contact can't nudge a foot off its bone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)