### PR TITLE
0.3.x budget: hard cap with stagger downgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@
   stagger and persistent transitions, physics→skeleton sync, and the real `FootIKSolver`
   planting feet over ground. `test_state_machine.gd` and `test_foot_ik.gd` were refactored
   to drive the real controller/solver rather than re-implement their formulas. Shared
-  builder: `test/helpers/rig_harness.gd`. Suite is now 84 tests.
+  builder: `test/helpers/rig_harness.gd`. Also covers the budget hard cap (downgrade vs
+  bypass, slot accounting). Suite is now 89 tests.
 
 ### Fixed
 - **Multi-rig safety** — balance-driven stagger/ragdoll no longer silently disables on
@@ -61,10 +62,14 @@
   partial-ragdoll recursion guard is correct on any rig.
 
 ### Changed
-- **Budget manager wired in** — `ActiveRagdollController` requests a slot from
-  `KickbackManager` on full ragdoll and releases it on recovery/removal (discovered via
-  the `kickback_manager` group). Currently a soft cap — the ragdoll still proceeds when
-  over budget; hard enforcement/eviction is a follow-up.
+- **Budget hard cap** — `KickbackManager` (default 5 slots, discovered via the
+  `kickback_manager` group) now actually bounds simultaneous ragdolls. When a slot is
+  denied, a *spontaneous* hit- or balance-driven full ragdoll is downgraded to a stagger
+  (the character still reacts but skips the expensive limp/settle/get-up cycle), and a
+  tipping-over character retries on later frames so it ragdolls as soon as a slot frees up.
+  Explicit `trigger_ragdoll()` and `set_persistent()` (death/knockdown) bypass the cap — a
+  deliberate or death ragdoll must always proceed. Slots are released on recovery/removal.
+  With no manager present, ragdolls stay unbounded. (Supersedes the earlier soft cap.)
 - Moved `strip_root_motion.gd` from `demo/` to `addons/kickback/editor/`.
 - **Demos consolidated** (11 → 8). `ball_throw` folded into `shooting_range` as a
   right-click ball-throw alt-fire (velocity-scaled impact, mouse-wheel throw strength).

--- a/addons/kickback/active_ragdoll_controller.gd
+++ b/addons/kickback/active_ragdoll_controller.gd
@@ -318,10 +318,13 @@ func _update_stagger(delta: float) -> void:
 	balance_changed.emit(balance)
 
 	if has_support:
-		# Too far off-balance → ragdoll (tipping over)
+		# Too far off-balance → ragdoll (tipping over). Hard cap: if the budget
+		# denies the slot, keep fighting in stagger instead of a full fall — and
+		# retry on later frames, so it ragdolls as soon as a slot frees up.
 		if balance > _tuning.balance_ragdoll_threshold:
-			_full_ragdoll()
-			return
+			if _try_acquire_ragdoll_slot():
+				_full_ragdoll()
+				return
 
 		# Regained balance → early recovery
 		if balance < _tuning.balance_recovery_threshold:
@@ -475,7 +478,9 @@ func _handle_stagger_hit(body: RigidBody3D, hit_dir: Vector3, effective_reductio
 	_reduce_strength(body.name, effective_reduction, profile.strength_spread)
 	_spring.recovery_rate = profile.recovery_rate
 	var boosted_prob := profile.ragdoll_probability * _tuning.stagger_ragdoll_bonus
-	if randf() < boosted_prob:
+	# Hard cap: if the budget denies the slot, fall through to extend the stagger
+	# (the cheaper reaction) rather than ragdoll.
+	if randf() < boosted_prob and _try_acquire_ragdoll_slot():
 		_full_ragdoll()
 	else:
 		_stagger_elapsed = 0.0  # Extend stagger
@@ -492,7 +497,10 @@ func _handle_normal_hit(body: RigidBody3D, hit_dir: Vector3, effective_reduction
 	if not should_ragdoll and _tuning.pain_ragdoll_threshold > 0.0:
 		should_ragdoll = _pain >= _tuning.pain_ragdoll_threshold
 	if should_ragdoll:
-		_full_ragdoll()
+		if _try_acquire_ragdoll_slot():
+			_full_ragdoll()
+		else:
+			_start_stagger(hit_dir)  # hard cap: downgrade to the cheaper reaction
 		return
 
 	# Stagger check: strength ratio + balance + pain-driven escalation
@@ -686,8 +694,12 @@ func _full_ragdoll() -> void:
 	state_changed.emit(_state)
 	ragdoll_started.emit()
 
-	# Request a budget slot if a KickbackManager is present. On denial the ragdoll
-	# still proceeds (soft cap); we simply don't hold a slot to release later.
+	# Budget slot bookkeeping. Spontaneous hit/balance ragdolls already reserved a
+	# slot via _try_acquire_ragdoll_slot() (so this is a no-op for them). Explicit
+	# trigger_ragdoll()/set_persistent() reach here WITHOUT a reservation and
+	# acquire opportunistically — they bypass the hard cap (a scripted or death
+	# ragdoll must always proceed) but still hold a slot for accurate accounting
+	# when one is free.
 	if not _holds_ragdoll_slot:
 		var mgr := _resolve_manager()
 		if mgr:
@@ -1042,6 +1054,23 @@ func _resolve_manager() -> Node:
 		if m and m.has_method("request_active_ragdoll"):
 			_manager = m
 	return _manager
+
+
+## Tries to reserve a budget slot for a NEW spontaneous full ragdoll. Returns
+## true (caller may ragdoll) when a slot is granted, when one is already held, or
+## when no KickbackManager is present (unbudgeted). Returns false ONLY when a
+## manager is present and at capacity — the hard cap, telling the caller to
+## substitute a cheaper reaction (stagger). Explicit trigger_ragdoll() and
+## set_persistent() do NOT gate on this: deliberate and death ragdolls always
+## proceed (a scripted death must not silently become a stagger).
+func _try_acquire_ragdoll_slot() -> bool:
+	if _holds_ragdoll_slot:
+		return true
+	var mgr := _resolve_manager()
+	if not mgr:
+		return true
+	_holds_ragdoll_slot = mgr.request_active_ragdoll()
+	return _holds_ragdoll_slot
 
 
 func _release_ragdoll_slot() -> void:

--- a/addons/kickback/kickback_manager.gd
+++ b/addons/kickback/kickback_manager.gd
@@ -1,5 +1,14 @@
-## Global budget manager for Kickback. Tracks how many active ragdolls are
-## currently simulating. Add as an autoload or place in the scene root.
+## Global budget manager for Kickback. Caps how many active ragdolls simulate at
+## once. Add as an autoload or place in the scene root — controllers discover it
+## via the [constant GROUP] group, so no wiring is needed.
+##
+## The cap is HARD for spontaneous reactions: when [method request_active_ragdoll]
+## denies a slot, a hit- or balance-driven full ragdoll is downgraded to a stagger
+## (the character still reacts, but skips the expensive limp/settle/get-up cycle).
+## Explicit [method ActiveRagdollController.trigger_ragdoll] and
+## [method ActiveRagdollController.set_persistent] bypass the cap — a deliberate or
+## death ragdoll must always proceed. If no manager is present, ragdolls are
+## unbounded.
 @icon("res://addons/kickback/icons/kickback_manager.svg")
 extends Node
 

--- a/test/test_budget.gd
+++ b/test/test_budget.gd
@@ -1,0 +1,103 @@
+extends GutTest
+
+# ── Budget hard cap ─────────────────────────────────────────────────────────
+# Verifies KickbackManager's hard cap: spontaneous hit/balance ragdolls are
+# downgraded to a stagger when no slot is free, while explicit trigger_ragdoll()
+# and set_persistent() (death/knockdown) bypass the cap. Drives the real
+# controller + manager on a live rig via res://test/helpers/rig_harness.gd.
+
+const RigHarness := preload("res://test/helpers/rig_harness.gd")
+const KickbackManager := preload("res://addons/kickback/kickback_manager.gd")
+
+
+func _fast_tuning() -> RagdollTuning:
+	var t := RagdollTuning.create_default()
+	t.foot_ik_enabled = false
+	t.ragdoll_force_recovery_time = 0.4
+	t.recovery_duration = 0.4
+	t.safety_timeout = 0.6
+	t.settle_duration = 0.15
+	return t
+
+
+func _spawn(tuning: RagdollTuning):
+	var h = RigHarness.new()
+	add_child_autoqfree(h)
+	h.setup(tuning, null, true)
+	var ok: bool = await h.await_ready(40)
+	assert_true(ok, "Kickback setup completed within frame budget")
+	return h
+
+
+# Adds a budget manager to the tree (it joins the "kickback_manager" group on
+# enter, which is how the controller discovers it).
+func _add_manager(max_slots: int):
+	var m = KickbackManager.new()
+	m.max_active_ragdolls = max_slots
+	add_child_autoqfree(m)
+	return m
+
+
+# A hit that deterministically WANTS a full ragdoll (probability 1.0), so the
+# only variable is whether the budget grants the slot.
+func _ragdoll_impact() -> ImpactProfile:
+	var p := ImpactProfile.new()
+	p.base_impulse = 5.0
+	p.impulse_transfer_ratio = 0.3
+	p.ragdoll_probability = 1.0
+	p.strength_reduction = 0.5
+	p.strength_spread = 0
+	p.recovery_rate = 1.0
+	return p
+
+
+func _hit(h) -> void:
+	var chest: RigidBody3D = h.get_body("Chest")
+	h.controller.apply_hit(chest, Vector3.FORWARD, chest.global_position, _ragdoll_impact())
+
+
+# ── Hard cap on spontaneous hit ragdolls ────────────────────────────────────
+
+func test_over_budget_hit_downgrades_to_stagger():
+	var h = await _spawn(_fast_tuning())
+	_add_manager(0)  # no slots available
+	_hit(h)
+	assert_eq(h.controller.get_state(), ActiveRagdollController.State.STAGGER,
+		"hard cap downgrades a would-be ragdoll to a stagger")
+
+
+func test_within_budget_hit_ragdolls_and_counts():
+	var h = await _spawn(_fast_tuning())
+	var mgr = _add_manager(5)
+	_hit(h)
+	assert_eq(h.controller.get_state(), ActiveRagdollController.State.RAGDOLL,
+		"a granted slot allows the full ragdoll")
+	assert_eq(mgr.get_active_ragdoll_count(), 1, "manager counts the active ragdoll")
+
+
+func test_recovery_releases_budget_slot():
+	var h = await _spawn(_fast_tuning())
+	var mgr = _add_manager(5)
+	_hit(h)
+	assert_eq(mgr.get_active_ragdoll_count(), 1, "slot held during ragdoll")
+	var recovered: bool = await wait_for_signal(h.controller.recovery_finished, 8.0)
+	assert_true(recovered, "ragdoll recovered")
+	assert_eq(mgr.get_active_ragdoll_count(), 0, "recovery released the slot")
+
+
+# ── Explicit / death ragdolls bypass the cap ────────────────────────────────
+
+func test_explicit_trigger_ragdoll_bypasses_cap():
+	var h = await _spawn(_fast_tuning())
+	_add_manager(0)  # no slots
+	h.controller.trigger_ragdoll()
+	assert_eq(h.controller.get_state(), ActiveRagdollController.State.RAGDOLL,
+		"explicit trigger_ragdoll ignores the budget")
+
+
+func test_persistent_bypasses_cap():
+	var h = await _spawn(_fast_tuning())
+	_add_manager(0)  # no slots
+	h.controller.set_persistent(true)
+	assert_eq(h.controller.get_state(), ActiveRagdollController.State.PERSISTENT,
+		"set_persistent (death/knockdown) ignores the budget")

--- a/test/test_budget.gd.uid
+++ b/test/test_budget.gd.uid
@@ -1,0 +1,1 @@
+uid://d0av7irby0255


### PR DESCRIPTION
## Workstream 5 — budget enforcement

`KickbackManager` (default 5 slots, discovered via the `kickback_manager` group) was wired but a **soft cap**: over-budget ragdolls still proceeded, so the budget was telemetry only. Per the design decision, this makes it a **hard cap that downgrades to the cheaper reaction**.

### Behavior
- **Spontaneous** hit- and balance-driven full ragdolls reserve a slot first (`_try_acquire_ragdoll_slot`). On denial they **downgrade to a stagger** — the character still reacts (on-feet wobble, fast recovery) but skips the expensive limp + settle + get-up cycle. A character tipping over in stagger retries each frame, so it ragdolls the moment a slot frees up.
- **Explicit `trigger_ragdoll()` and `set_persistent()` (death/knockdown) bypass the cap.** A deliberate or death ragdoll must always proceed — silently downgrading a scripted death to a stagger would be wrong. They still acquire a slot opportunistically for accurate `get_active_ragdoll_count()`.
- **No manager present → unbounded** (unchanged).

### Scope note
The cap intentionally applies only to the automatic reactions that scale with combat (the cost driver), not to explicit/death ragdolls. If you'd prefer the cap to also gate `trigger_ragdoll()`, say so and I'll adjust.

### Tests — `test/test_budget.gd` (new, +5)
Uses the runtime rig harness from #64 to drive the real controller + manager on a live rig:
- over-budget hit → `STAGGER` (downgrade)
- within-budget hit → `RAGDOLL`, manager count = 1
- recovery releases the slot (count back to 0)
- `trigger_ragdoll()` and `set_persistent()` ignore a 0-slot cap

### Validation
- Clean headless `--import` (exit 0).
- **89 tests pass, stable across 4 consecutive headless runs.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)