### PR TITLE
fix(ci): run release workflow tests on Godot 4.7

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,8 +11,8 @@ body:
     id: godot-version
     attributes:
       label: Godot Version
-      description: e.g. 4.6.1
-      placeholder: "4.6.1"
+      description: e.g. 4.7
+      placeholder: "4.7"
     validations:
       required: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Download Godot 4.6.1
+      - name: Download Godot 4.7
         run: |
-          wget -q https://github.com/godotengine/godot/releases/download/4.6.1-stable/Godot_v4.6.1-stable_linux.x86_64.zip
-          unzip -q Godot_v4.6.1-stable_linux.x86_64.zip
-          chmod +x Godot_v4.6.1-stable_linux.x86_64
-          mv Godot_v4.6.1-stable_linux.x86_64 godot
+          wget -q https://github.com/godotengine/godot/releases/download/4.7-stable/Godot_v4.7-stable_linux.x86_64.zip
+          unzip -q Godot_v4.7-stable_linux.x86_64.zip
+          chmod +x Godot_v4.7-stable_linux.x86_64
+          mv Godot_v4.7-stable_linux.x86_64 godot
 
       - name: Import project
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@
   [EUPHORIA_COMPARISON.md](docs/EUPHORIA_COMPARISON.md) with honest real/partial/nominal
   classifications.
 - **Upgraded to Godot 4.7** — `project.godot` features, all documentation version
-  references, and CI bumped from 4.6.1 to 4.7. Validated: clean headless import +
-  76/76 GUT tests pass.
+  references, and CI (both the `tests` and `release` workflows) bumped from 4.6.1 to 4.7.
+  Validated: clean headless import + GUT suite passing.
 
 ### Added
 - **Semantic role accessors on `RagdollProfile`** — `get_root_rig`, `get_chest_rig`,


### PR DESCRIPTION
## Why

`release.yml` still downloaded **Godot 4.6.1** for its gating `test` job, while `tests.yml` had already moved to **4.7**. Tagging `v0.3.0` would have run the release-gating tests against the wrong engine — directly contradicting the CHANGELOG's "CI bumped from 4.6.1 to 4.7" claim, and risking 4.7-only behavior (e.g. the `SkeletonModifier3D` migration paths) being validated differently than shipped.

This is the one item that blocked a clean `0.3.0` tag.

## Changes

- `release.yml` — download `4.7-stable` (now mirrors `tests.yml` exactly).
- `bug_report.yml` — Godot-version placeholder `4.6.1` → `4.7`.
- `CHANGELOG.md` — the "CI bumped to 4.7" bullet now accurately says **both** the `tests` and `release` workflows (it previously over-claimed).

## Validation

- No code touched; `.github/` is now free of any `4.6` references.
- The tag↔`plugin.cfg` version-validation step in `release.yml` is unchanged and correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)