### PR TITLE
docs: 0.3.x accuracy sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,12 @@ kickback/
 │   ├── STEP_BY_STEP.md              # Implementation history
 │   ├── GODOT_CONSTRAINTS.md         # Engine quirks and workarounds
 │   ├── REFERENCE.md                 # Technical reference: math, profiles, bone mapping
-│   └── INTEGRATION.md              # Integration guide: timing, layers, state machine, scoring
+│   ├── INTEGRATION.md               # Integration guide: timing, layers, state machine, scoring
+│   ├── FOOT_IK.md                   # Foot IK solver: planting, pelvis drop, anti-slide
+│   ├── EUPHORIA_COMPARISON.md       # Feature-gap analysis vs Euphoria (honest scorecard)
+│   ├── ROADMAP.md                   # Difficulty-weighted parity scorecard + milestones
+│   ├── VERSIONING.md                # What the version numbers mean
+│   └── SKELETON_MODIFIER_MIGRATION.md  # PhysicsRigSync → SkeletonModifier3D record
 ├── addons/
 │   └── kickback/                    # The plugin (distributable)
 │       ├── plugin.cfg
@@ -28,10 +33,12 @@ kickback/
 │       ├── kickback_character.gd    # Coordinator (detects mode, routes hits)
 │       ├── kickback_manager.gd      # Global budget manager
 │       ├── kickback_raycast.gd      # Hit detection utility (one-liner)
+│       ├── kickback_layers.gd       # Collision-layer constants (active=4, partial=5)
 │       ├── skeleton_detector.gd     # Auto-detect humanoid bones in any skeleton
 │       ├── physics_rig_builder.gd   # Builds RigidBody3D ragdoll rig
 │       ├── physics_rig_sync.gd      # Syncs physics → visible skeleton
 │       ├── spring_resolver.gd       # Velocity-based spring pose matching
+│       ├── foot_ik_solver.gd        # Two-bone foot IK (direct math → spring targets)
 │       ├── active_ragdoll_controller.gd  # State machine (NORMAL/STAGGER/RAGDOLL/GETTING_UP/PERSISTENT)
 │       ├── partial_ragdoll_controller.gd # Standalone selective bone simulation
 │       ├── physics_collision_monitor.gd # Optional ragdoll-environment collision observer
@@ -41,6 +48,7 @@ kickback/
 │       ├── editor/                  # Editor-only tooling
 │       │   ├── kickback_inspector_plugin.gd
 │       │   ├── kickback_status_panel.gd
+│       │   ├── rig_baker.gd         # Bake persistent RigidBody3D + Joint nodes to scene
 │       │   └── strip_root_motion.gd # Tool to strip root motion from animations
 │       ├── icons/                   # Scene tree icons (SVG)
 │       ├── presets/                  # Starter ImpactProfile .tres files
@@ -78,7 +86,7 @@ kickback/
 
 ### Active Ragdoll
 - `PhysicsRigBuilder` creates 16 RigidBody3D + 15 Generic6DOFJoint3D
-- `PhysicsRigSync` writes physics transforms to skeleton as bone pose overrides
+- `PhysicsRigSync` (a `SkeletonModifier3D`) writes physics transforms onto the skeleton each frame; the engine rolls the write back after skinning, so the spring's `get_bone_pose()` animation target stays clean
 - `SpringResolver` drives physics bodies toward animation poses via velocity lerp
 - `ActiveRagdollController` manages NORMAL → STAGGER/RAGDOLL → GETTING_UP → NORMAL state machine
 - `STAGGER` state: springs reduced to floor strength, continuous sway force fights springs for visible wobble, Active Resistance dynamically adjusts per-bone strengths based on balance/CoM

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ and **[VERSIONING.md](docs/VERSIONING.md)** for what the numbers mean.
 - **Configurable everything** — skeleton mapping (`RagdollProfile`), physics tuning (`RagdollTuning`), impact parameters (`ImpactProfile`) — all via Resources with sensible defaults.
 - **Hit detection utility** — `KickbackRaycast.shoot_from_camera()` handles raycast + routing in one line.
 - **Debug gizmos** — F3 cycles through 3 detail levels: bone dots → skeleton wireframe + state labels → full dashboard with status panels, center of mass, velocity vectors, and balance/fatigue bars.
-- **10 demo scenes** — comparison, shooting range, signals, tuning playground, stress test, animated NPC, ball throwing, tuning presets, protected bones, euphoria showcase.
+- **8 demo scenes** — comparison, shooting range, signals, tuning playground, stress test, animated NPC, foot IK, euphoria showcase.
 
 ## Requirements
 
@@ -158,7 +158,7 @@ Or use the preset `.tres` files in `addons/kickback/presets/`.
 Character (Node3D)
 ├── KickbackCharacter (coordinator — detects mode, routes hits)
 ├── PhysicsRigBuilder (creates 16 RigidBody3D + 15 joints)
-├── PhysicsRigSync (physics → skeleton bone overrides)
+├── PhysicsRigSync (SkeletonModifier3D: physics → skeleton)
 ├── SpringResolver (animation → physics velocity springs)
 └── ActiveRagdollController (NORMAL/STAGGER/RAGDOLL/GETTING_UP/PERSISTENT)
 ```

--- a/docs/EUPHORIA_COMPARISON.md
+++ b/docs/EUPHORIA_COMPARISON.md
@@ -36,7 +36,7 @@ and systems with difficulty ratings and implementation notes for Godot 4.7+.
 - 🟡 Cumulative pain / fatigue — decaying scalars that scale existing strength reductions
 - ⚪ Regional impairment — a per-bone injury scalar feeding a multiplier; no limb-specific behavior
 - ⚪ Threat anticipation — one strength pulse + a signal (a flinch knob, not anticipatory posture)
-- ⚪ Budget system for concurrent ragdolls — `KickbackManager` counter is **not wired** into controllers
+- 🟡 Budget hard-cap for concurrent ragdolls — `KickbackManager` bounds simultaneous ragdolls; over-budget *spontaneous* ragdolls downgrade to a stagger, while explicit/death ragdolls bypass. (A count-based cap, not LOD/quality tiers.)
 
 ### The objective — absent (this is what 1.0 means)
 Every behavior that makes Euphoria *Euphoria* — active balance recovery, stumble steps,

--- a/docs/GODOT_CONSTRAINTS.md
+++ b/docs/GODOT_CONSTRAINTS.md
@@ -1,7 +1,7 @@
 # Godot Constraints and Workarounds
 
 Read this BEFORE writing any physics code. These are confirmed issues and
-workarounds specific to Godot 4.6+ with Jolt physics.
+workarounds specific to Godot 4.7+ with Jolt physics.
 
 ## Why we use RigidBody3D instead of PhysicalBone3D for active ragdoll
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -28,7 +28,7 @@ figure is **~30%**.)
 
 | Version | Theme | Delivers |
 |---------|-------|----------|
-| **0.3.x** | Re-baseline + hardening | Honest docs & scorecard (this release). Then: fix silent multi-rig degradation, wire-or-remove the budget manager, add runtime smoke tests, generalize beyond Mixamo. |
+| **0.3.x** | Re-baseline + hardening | Honest docs & scorecard, plus the hardening batch: fixed silent multi-rig degradation, wired the budget manager (hard cap), added runtime smoke tests, generalized beyond Mixamo, and migrated `PhysicsRigSync` to a `SkeletonModifier3D`. See *Known hardening items* for what's resolved vs still open. |
 | **0.4.0** | Self-Preservation | Procedural stumble steps + arm bracing — the first *active* survival behaviors. |
 | **0.5.0** | Environmental Awareness | Wall/surface bracing + ground crawling. |
 | **0.6.0** | World Interaction | Environmental grabbing (IK reach + physics pins to grab points). |

--- a/docs/SKELETON_MODIFIER_MIGRATION.md
+++ b/docs/SKELETON_MODIFIER_MIGRATION.md
@@ -25,8 +25,11 @@ review time, since headless cannot cover it.
 
 ## Why this exists
 
+> The file/line references in this and the following planning sections describe the
+> **pre-migration** code; see *As built* above for the shipped result.
+
 `PhysicsRigSync` pushes the physics ragdoll back onto the visible mesh with
-`Skeleton3D.set_bone_global_pose_override()` (`physics_rig_sync.gd:127`). That method has
+`Skeleton3D.set_bone_global_pose_override()` (pre-migration `physics_rig_sync.gd`). That method has
 been **deprecated since Godot 4.3** ("may be changed or removed in future versions"). It
 still works in 4.7 with no runtime warning, so there's no pressure today — but it will be
 removed in a future major (Godot 5 is the likely point), at which time the ragdoll mesh
@@ -166,4 +169,6 @@ expected change — not a regression.
 The code change is **localized** (essentially `physics_rig_sync.gd` plus node-placement
 wiring) but it is **structural** (node moves under the skeleton) and **visually sensitive**
 (it's the core render path of the ragdoll). It cannot be fully validated by automated tests.
-That combination is why it's a dedicated `0.9.0` milestone rather than a cleanup PR.
+That combination is why it was carved out as its own focused, visually-validated PR —
+ultimately pulled forward and shipped in `0.3.0` rather than waiting for the original
+`0.9.0` hardening slot.

--- a/docs/STEP_BY_STEP.md
+++ b/docs/STEP_BY_STEP.md
@@ -138,6 +138,11 @@ Used standalone for far targets, combined with partial ragdoll for mid-range.
 
 ## Step 3 — Dual-skeleton physics rig ✅ COMPLETE
 
+> **Update (0.3.0):** the sync layer described below was later migrated from
+> `set_bone_global_pose_override` to a `SkeletonModifier3D` (its per-frame roll-back keeps
+> the spring's `get_bone_pose()` animation target clean). The steps here record the
+> *original* implementation — see [SKELETON_MODIFIER_MIGRATION.md](SKELETON_MODIFIER_MIGRATION.md).
+
 **Goal**: Build the RigidBody3D skeleton that will become the active ragdoll.
 No spring resolver yet — just verify the physics rig works as a passive ragdoll.
 
@@ -409,7 +414,7 @@ One-click "Add Kickback to character", visual strength debugger, weapon profile
 editor, collision shape visualization.
 
 **Status**: Complete. Key features:
-- Tool menu "Add Kickback to Selected": creates all 7 controller nodes with auto-wired NodePaths
+- Tool menu "Add Kickback to Selected": creates the Active-Ragdoll node set (5 nodes; 2 for Partial Ragdoll) with auto-wired NodePaths
 - Validates Skeleton3D + AnimationPlayer prerequisites, prevents duplicates
 - Undoable via EditorUndoRedoManager
 - StrengthDebugHUD: 2D overlay (F3 toggle) showing per-bone strength as colored dots


### PR DESCRIPTION
Brings the docs in line with the shipped 0.3.x code. All findings verified against source.

## Fixes

- **`EUPHORIA_COMPARISON.md`** — the budget system was listed as ⚪ "not wired", but it's been a wired **hard cap** since PR #65 (this contradicted both `ROADMAP.md` and the `CHANGELOG`). Reclassified 🟡 with an accurate description (downgrade-to-stagger; explicit/death bypass).
- **`CLAUDE.md`** — the structure tree was missing `foot_ik_solver.gd`, `kickback_layers.gd`, `editor/rig_baker.gd`, and 5 of the 9 docs. The Active-Ragdoll architecture note still said "bone pose overrides" — updated to describe `PhysicsRigSync` as a `SkeletonModifier3D` whose per-frame roll-back keeps the spring's `get_bone_pose()` target clean.
- **`README.md`** — "10 demo scenes" (and the 3 merged-away scenes) → the actual **8**; architecture box "bone overrides" → `SkeletonModifier3D`.
- **`STEP_BY_STEP.md`** — Step 3 still described the old `set_bone_global_pose_override` sync as current; added a forward-pointer to `SKELETON_MODIFIER_MIGRATION.md` (kept the history). "7 controller nodes" → "5 (Active) / 2 (Partial)".
- **`SKELETON_MODIFIER_MIGRATION.md`** — flagged the stale `physics_rig_sync.gd:127` line anchors as pre-migration; reconciled the "0.9.0 milestone" line with the "shipped in 0.3.0" header.
- **`ROADMAP.md`** — 0.3.x row updated from a TODO list to the resolved batch.
- **`GODOT_CONSTRAINTS.md`** — "Godot 4.6+" → "4.7+".

## Deliberately out of scope

- The README **Collision Layers** table is left for the upcoming layer-standardization PR, so the doc changes atomically with the code (the project is currently inconsistent: defaults use layer 1, demos/constant use layer 2).
- The `CHANGELOG` `[0.3.0]` two-`### Changed`-blocks tidy-up is a later cosmetic pass (the content is accurate; a 37-line unicode-sensitive move now would be risk without benefit).

## Validation

Pure documentation. CI runs the full headless import + GUT suite on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)