### PR TITLE
refactor: remove vestigial RagdollAnimator hook + dead methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,10 @@
   `shooting_range` and `tuning_playground` — see Changed above).
 - Stray debug `print()` output across setup/baking/HUD paths (meaningful notices kept as
   `push_warning`).
+- The vestigial `RagdollAnimator` hook — the write-only `_anim_player` field, the
+  `animation_player_path` export, and the setup tool's `AnimationPlayer` detection that fed
+  it. Nothing consumed it (the controllers are animation-agnostic by design). Also removed
+  the unused `JoltCheck.warn_if_not_jolt()` and `KickbackCharacter.get_mode_name()`.
 
 ---
 

--- a/addons/kickback/jolt_check.gd
+++ b/addons/kickback/jolt_check.gd
@@ -7,11 +7,3 @@ class_name JoltCheck
 static func is_jolt_active() -> bool:
 	var engine_name := ProjectSettings.get_setting("physics/3d/physics_engine", "") as String
 	return engine_name == "Jolt Physics" or engine_name == "JoltPhysics3D"
-
-
-## Prints a warning and returns false if Jolt is not active.
-static func warn_if_not_jolt() -> bool:
-	if not is_jolt_active():
-		push_warning("Kickback: Jolt Physics is not active. Ragdoll will not work correctly.")
-		return false
-	return true

--- a/addons/kickback/kickback_character.gd
+++ b/addons/kickback/kickback_character.gd
@@ -15,8 +15,6 @@ enum Mode {
 @export_group("References")
 ## Path to the Skeleton3D node that drives this character's mesh.
 @export var skeleton_path: NodePath
-## Path to the AnimationPlayer (optional — only needed if using RagdollAnimator).
-@export var animation_player_path: NodePath
 ## Path to the character's root Node3D (gameplay root, not model sub-node).
 ## This node is teleported during ragdoll recovery. The setup tool defaults to
 ## ".." assuming Kickback nodes are direct children of the character root. If
@@ -35,7 +33,6 @@ enum Mode {
 @export_enum("Normal", "Ragdoll", "Persistent") var initial_state: String = "Normal"
 
 var _skeleton: Skeleton3D
-var _anim_player: AnimationPlayer
 var _character_root: Node3D
 var _simulator: PhysicalBoneSimulator3D
 
@@ -61,9 +58,6 @@ func _ready() -> void:
 
 	# Set skeleton modifier callback to Physics so IK and spring resolver stay in sync
 	_skeleton.modifier_callback_mode_process = Skeleton3D.MODIFIER_CALLBACK_MODE_PROCESS_PHYSICS
-
-	if not animation_player_path.is_empty():
-		_anim_player = get_node_or_null(animation_player_path) as AnimationPlayer
 
 	if not character_root_path.is_empty():
 		_character_root = get_node_or_null(character_root_path) as Node3D
@@ -166,15 +160,6 @@ func receive_hit(body_or_bone: CollisionObject3D, hit_dir: Vector3, hit_pos: Vec
 ## Returns the current mode as a [enum Mode] value.
 func get_mode() -> int:
 	return _mode
-
-
-## Returns a human-readable label for the current mode.
-func get_mode_name() -> String:
-	match _mode:
-		Mode.ACTIVE: return "ACTIVE"
-		Mode.PARTIAL: return "PARTIAL"
-		Mode.NONE: return "NONE"
-	return "UNKNOWN"
 
 
 ## Returns true if the character is in full ragdoll, getting up, or persistent ragdoll.

--- a/addons/kickback/kickback_plugin.gd
+++ b/addons/kickback/kickback_plugin.gd
@@ -5,7 +5,6 @@ extends EditorPlugin
 var _inspector_plugin: EditorInspectorPlugin
 var _pending_root: Node
 var _pending_skeleton: Skeleton3D
-var _pending_anim_player: AnimationPlayer
 
 
 func _enter_tree() -> void:
@@ -42,7 +41,6 @@ func _on_add_kickback() -> void:
 
 	_pending_root = root
 	_pending_skeleton = skeleton
-	_pending_anim_player = _find_child_of_type(root, "AnimationPlayer")
 
 	_show_preset_dialog()
 
@@ -128,10 +126,8 @@ func _show_preset_dialog() -> void:
 func _execute_preset(preset_name: String) -> void:
 	var root := _pending_root
 	var skeleton := _pending_skeleton
-	var anim_player := _pending_anim_player
 
 	var skeleton_name := skeleton.name
-	var anim_name: String = anim_player.name if anim_player else ""
 	var simulator_path := "../%s/PhysicalBoneSimulator3D" % skeleton_name
 	var scene_owner: Node = root.owner if root.owner else root
 
@@ -195,8 +191,6 @@ func _execute_preset(preset_name: String) -> void:
 	kc.name = "KickbackCharacter"
 	kc.set_script(scripts["kickback_character"])
 	kc.set("skeleton_path", NodePath("../%s" % skeleton_name))
-	if anim_player:
-		kc.set("animation_player_path", NodePath("../%s" % anim_name))
 	kc.set("character_root_path", NodePath(".."))
 	kc.set("ragdoll_profile", auto_profile)
 	nodes.append(kc)


### PR DESCRIPTION
Pure dead-code removal (29 deletions, 0 insertions).

## What & why

A long-removed **`RagdollAnimator`** concept left a ghost trail: an `animation_player_path` export, set by the setup tool, resolved in `_ready` into a `_anim_player` field that **nothing ever reads**. The physics controllers are animation-agnostic by design (they emit signals, never play animations), so the field served no purpose.

Removed:
- `KickbackCharacter._anim_player` field + its `_ready` resolver, the `animation_player_path` export, and the stale doc comment referencing `RagdollAnimator`.
- The setup tool's `AnimationPlayer` detection (`_pending_anim_player`, the `_find_child_of_type` lookup, the `kc.set("animation_player_path", …)`) that existed only to populate that export.
- `JoltCheck.warn_if_not_jolt()` — unused; `is_jolt_active()` is called directly.
- `KickbackCharacter.get_mode_name()` — unused, undocumented (the status panel computes its own label).

## Safety

- `grep` confirms no `.tscn` or test references `animation_player_path`, so removing the export orphans no scene property.
- `get_mode()` (the enum getter, used by tests) is untouched.

## Validation

Clean headless import (no parse/script errors) + **89/89** GUT tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)