### PR TITLE
fix: route tuning foot-IK validation through profile roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,11 @@
 - **`RagdollProfile.root_bone`** no longer defaults to the Mixamo-specific `"mixamorig_Hips"`.
   It defaults to empty and derives from `root_rig` via `get_root_skeleton_bone()`, so the
   partial-ragdoll recursion guard is correct on any rig.
+- **`RagdollTuning.validate_against_profile`** foot-IK check now resolves feet/legs through the
+  profile's semantic roles (`foot_rigs` / `left_leg_chain` / `right_leg_chain`) instead of the
+  hardcoded `Foot_L`/`UpperLeg_L`/… names, matching `RagdollProfile.validate_against_skeleton`.
+  Non-Mixamo rigs that set the role fields no longer get spurious "foot_ik requires 'Foot_L'"
+  warnings. (Completes the PR #62 de-hardcoding, which missed this one validator.)
 
 ### Changed
 - **Budget hard cap** — `KickbackManager` (default 5 slots, discovered via the

--- a/addons/kickback/resources/ragdoll_tuning.gd
+++ b/addons/kickback/resources/ragdoll_tuning.gd
@@ -476,9 +476,15 @@ func validate_against_profile(profile: RagdollProfile) -> PackedStringArray:
 		if bone_name not in valid_names:
 			warnings.append("core_bracing_bones entry '%s' not found in profile rig names" % bone_name)
 
+	# Foot IK resolves feet/legs through the profile's semantic roles, not hardcoded
+	# Mixamo names — mirror RagdollProfile.validate_against_skeleton so a non-Mixamo rig
+	# with its role fields set doesn't get spurious "requires 'Foot_L'" warnings.
 	if foot_ik_enabled:
-		for foot_name in ["Foot_L", "Foot_R", "UpperLeg_L", "UpperLeg_R", "LowerLeg_L", "LowerLeg_R"]:
-			if foot_name not in valid_names:
-				warnings.append("foot_ik requires '%s' in profile but not found" % foot_name)
+		if profile.get_foot_rigs().size() < 2:
+			warnings.append("foot_ik_enabled requires two foot bodies (profile foot_rigs role)")
+		for side: String in ["L", "R"]:
+			if profile.get_leg_chain(side).is_empty():
+				warnings.append("foot_ik_enabled requires a complete %s leg chain (profile %s_leg_chain role)" % [
+					side, "left" if side == "L" else "right"])
 
 	return warnings

--- a/test/test_tuning_validation.gd
+++ b/test/test_tuning_validation.gd
@@ -86,3 +86,63 @@ func test_all_default_bone_names_valid():
 		valid_names.append(bone_def.rig_name)
 	for key: String in t.strength_map:
 		assert_has(valid_names, key, "strength_map key '%s' should be valid" % key)
+
+
+# --- Foot-IK validation resolves via semantic roles, not hardcoded Mixamo names ---
+
+func _make_custom_leg_profile() -> RagdollProfile:
+	# A non-Mixamo rig: feet/legs use custom names exposed via the role fields.
+	var p := RagdollProfile.new()
+	for rig_name: String in ["pelvis", "thighL", "shinL", "footL", "thighR", "shinR", "footR"]:
+		var bd := BoneDefinition.new()
+		bd.rig_name = rig_name
+		bd.skeleton_bone = rig_name
+		p.bones.append(bd)
+	p.root_rig = "pelvis"
+	p.foot_rigs = PackedStringArray(["footL", "footR"])
+	p.left_leg_chain = PackedStringArray(["thighL", "shinL", "footL"])
+	p.right_leg_chain = PackedStringArray(["thighR", "shinR", "footR"])
+	return p
+
+
+func _bare_tuning() -> RagdollTuning:
+	# Default tuning with the rig-name dicts cleared, so only the foot-IK role check
+	# can contribute warnings (the default dicts hold Mixamo keys absent from custom rigs).
+	var t := RagdollTuning.create_default()
+	t.strength_map = {}
+	t.pin_strength_overrides = {}
+	t.ramp_delay = {}
+	t.min_strength = {}
+	t.protected_bones = PackedStringArray()
+	t.core_bracing_bones = PackedStringArray()
+	return t
+
+
+func test_foot_ik_accepts_role_mapped_non_mixamo_legs():
+	# Regression: the validator used to hardcode "Foot_L"/"UpperLeg_L"/... and would
+	# wrongly warn here even though foot IK actually resolves feet/legs via roles.
+	var t := _bare_tuning()
+	t.foot_ik_enabled = true
+	var w := t.validate_against_profile(_make_custom_leg_profile())
+	assert_eq(w.size(), 0, "role-mapped feet/legs should satisfy foot_ik_enabled; got %s" % str(w))
+
+
+func test_foot_ik_warns_when_feet_absent():
+	var p := RagdollProfile.new()
+	var bd := BoneDefinition.new()
+	bd.rig_name = "pelvis"
+	p.bones.append(bd)
+	p.root_rig = "pelvis"
+	p.foot_rigs = PackedStringArray()
+	p.left_leg_chain = PackedStringArray()
+	p.right_leg_chain = PackedStringArray()
+	var t := _bare_tuning()
+	t.foot_ik_enabled = true
+	assert_true(t.validate_against_profile(p).size() >= 1, "foot_ik_enabled with no feet must warn")
+
+
+func test_foot_ik_disabled_skips_role_checks():
+	var p := RagdollProfile.new()  # no bones, no leg roles
+	var t := _bare_tuning()
+	t.foot_ik_enabled = false
+	assert_eq(t.validate_against_profile(p).size(), 0, "disabled foot_ik must not warn about missing feet")


### PR DESCRIPTION
## Why

`RagdollTuning.validate_against_profile` still hardcoded `["Foot_L","Foot_R","UpperLeg_L","UpperLeg_R","LowerLeg_L","LowerLeg_R"]` for its `foot_ik_enabled` check — a leftover the PR #62 de-hardcoding missed. Since this is the validator `KickbackCharacter._validate_setup` actually runs, a **non-Mixamo rig** that maps feet/legs under different names (with the semantic-role fields set) got spurious `foot_ik requires 'Foot_L'` warnings at setup, even though foot IK resolves fine through the roles. Its sibling `RagdollProfile.validate_against_skeleton` already did this correctly — the two validators disagreed.

## Change

The check now mirrors `validate_against_skeleton`: `profile.get_foot_rigs().size() >= 2` and a complete `get_leg_chain(side)` per side.

## Tests (`test_tuning_validation.gd`, +3)

- `test_foot_ik_accepts_role_mapped_non_mixamo_legs` — a custom-named leg rig (`footL`/`thighL`/…) with the role fields set satisfies `foot_ik_enabled` with **zero** warnings. This would have produced **6** warnings on the old hardcoded code, so it locks in the fix.
- `test_foot_ik_warns_when_feet_absent` — `foot_ik_enabled` with no feet still warns.
- `test_foot_ik_disabled_skips_role_checks` — disabling foot IK skips the check.

## Validation

Clean headless import + **92/92** GUT tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)