### PR TITLE
polish: KickbackManager class_name + API/DX docstring touch-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@
 - **`KickbackLayers`** — named collision-layer constants (active ragdoll = UI layer 4,
   partial ragdoll = UI layer 5) replacing magic numbers in `KickbackRaycast` and
   `SkeletonDetector`.
+- **`KickbackManager` registers a `class_name`** — the budget manager is now a first-class,
+  typeable node (it had an `@icon` but no `class_name`, so the icon was inert). Discovery is
+  still group-based; purely additive. Also clarified docstrings/tooltips (`balance_changed`
+  is stagger-only, `ImpactProfile.strength_spread` counts joint-hops, collision layer/mask
+  defaults) and gave `KickbackCharacter.anticipate_threat` the same no-controller
+  `push_warning` as the other facade mutators.
 - **Runtime / physics smoke tests** — the first automated coverage of the physics runtime
   (previously 0 %). The GUT suite now builds a real rig in a headless `SceneTree` — a
   synthetic Mixamo-named skeleton wired to `PhysicsRigBuilder` + `SpringResolver` +

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ Character (Node3D)
 - `threat_anticipated(direction, urgency)` — anticipate_threat() was called
 - `region_injured(rig_name, severity)` — bone sustained persistent injury
 
+**Optional component:** add a `PhysicsCollisionMonitor` next to the controllers to emit `body_impact(bone_name, velocity, contact_body)` whenever ragdoll bodies strike the environment — handy for impact SFX, decals, or scoring. See [INTEGRATION.md](docs/INTEGRATION.md).
+
 **Important:** All root movement and rotation must happen in `_physics_process`, not `_process`, to stay in sync with the spring resolver.
 
 ## Demo Scenes

--- a/addons/kickback/active_ragdoll_controller.gd
+++ b/addons/kickback/active_ragdoll_controller.gd
@@ -102,6 +102,7 @@ signal stagger_started(hit_direction: Vector3)
 ## Emitted when the character recovers from stagger and returns to NORMAL.
 signal stagger_finished()
 ## Emitted each physics frame during stagger with the current balance ratio.
+## Not emitted outside STAGGER — poll [method get_balance_ratio] for continuous monitoring.
 signal balance_changed(ratio: float)
 ## Emitted when fatigue level changes significantly. 0.0 = fresh, 1.0 = exhausted.
 signal fatigue_changed(level: float)

--- a/addons/kickback/kickback_character.gd
+++ b/addons/kickback/kickback_character.gd
@@ -193,6 +193,8 @@ func trigger_stagger(hit_dir: Vector3 = Vector3.FORWARD) -> void:
 func anticipate_threat(threat_dir: Vector3, urgency: float = 0.5) -> void:
 	if _active_controller:
 		_active_controller.anticipate_threat(threat_dir, urgency)
+	else:
+		push_warning("KickbackCharacter: no ActiveRagdollController available for anticipate_threat()")
 
 
 ## Returns the active ragdoll state name, or "N/A" if no active controller.

--- a/addons/kickback/kickback_manager.gd
+++ b/addons/kickback/kickback_manager.gd
@@ -10,6 +10,7 @@
 ## death ragdoll must always proceed. If no manager is present, ragdolls are
 ## unbounded.
 @icon("res://addons/kickback/icons/kickback_manager.svg")
+class_name KickbackManager
 extends Node
 
 @export_group("Budget")

--- a/addons/kickback/resources/impact_profile.gd
+++ b/addons/kickback/resources/impact_profile.gd
@@ -19,7 +19,8 @@ extends Resource
 @export_range(0.0, 1.0) var ragdoll_probability: float = 0.0
 ## How much spring strength is reduced on the hit bone (0 = none, 1 = full).
 @export_range(0.0, 1.0) var strength_reduction: float = 0.4
-## How many neighbor bones also lose strength (0 = hit bone only).
+## How far the strength reduction propagates through the joint graph, in hops
+## (0 = hit bone only, 1 = direct neighbors, 99 = effectively the whole body).
 @export_range(0, 99) var strength_spread: int = 1
 
 @export_group("Recovery")

--- a/addons/kickback/resources/ragdoll_tuning.gd
+++ b/addons/kickback/resources/ragdoll_tuning.gd
@@ -196,9 +196,11 @@ extends Resource
 # ── Collision ───────────────────────────────────────────────────────────────
 
 @export_group("Collision")
-## Physics collision layer for ragdoll bodies.
+## Physics layer the ragdoll bodies occupy (default 8 = UI layer 4,
+## [constant KickbackLayers.ACTIVE_RAGDOLL_LAYER]).
 @export_flags_3d_physics var collision_layer: int = 8
-## Physics collision mask for ragdoll bodies.
+## Layers the ragdoll bodies collide against (default 15 = UI layers 1-4: the
+## environment plus the other ragdoll bodies).
 @export_flags_3d_physics var collision_mask: int = 15
 ## Bones whose collision_mask is set to 0 during NORMAL state and restored on
 ## STAGGER/RAGDOLL. Prevents clipping from animation poses (crossed arms, etc.).


### PR DESCRIPTION
Small, non-breaking API/DX polish — all additive (no signatures changed).

## Changes

- **`KickbackManager` gets a `class_name`** — it had an `@icon` but no `class_name`, so the icon was inert and the budget manager wasn't a selectable/typeable node despite docs referring to it as a type. Discovery stays group-based; purely additive.
- **`KickbackCharacter.anticipate_threat`** now `push_warning`s when there's no active controller, matching `trigger_stagger` / `trigger_ragdoll` / `set_persistent` (it was the only facade mutator that silently no-op'd).
- **Docstrings/tooltips:**
  - `balance_changed` documents that it's **stagger-only** — poll `get_balance_ratio()` for continuous monitoring.
  - `ImpactProfile.strength_spread` reworded to "joint-hops" (it propagates through the joint graph; it is not a literal bone count): 0 = hit bone, 1 = neighbors, 99 = whole body.
  - `RagdollTuning.collision_layer`/`collision_mask` spell out the `8 = layer 4` / `15 = layers 1-4` defaults and reference `KickbackLayers`.
- **README** documents the optional `PhysicsCollisionMonitor` (previously only in `INTEGRATION.md`).

## Note

The setup-tool "Layer 2 = environment (ground raycasts)" line and the collision-layer reconciliation are intentionally **not** here — they belong to the upcoming environment-layer standardization PR (the project currently mixes layer 1 defaults with layer 2 docs/demos).

## Validation

Clean headless import + **92/92** GUT tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)