### PR TITLE
test: cover RagdollProfile validation + SkeletonDetector generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,13 @@
   to drive the real controller/solver rather than re-implement their formulas. Shared
   builder: `test/helpers/rig_harness.gd`. Also covers the budget hard cap (downgrade vs
   bypass, slot accounting). Suite is now 89 tests.
+- **Resource & detector validation tests** — `RagdollProfile.validate_against_skeleton`
+  (clean Mixamo round-trip plus each warning branch: missing skeleton/child bone, undefined
+  joint/role rig, absent feet, missing intermediate) in `test_profile_validation.gd`, and
+  `SkeletonDetector.create_collision_shape` (box/capsule/sphere) + `create_profile_from_skeleton`
+  (a 16-body/15-joint round-trip that re-validates clean) in `test_skeleton_detector.gd`. The
+  synthetic-skeleton builder was promoted to a reusable `RigHarness.build_mixamo_skeleton()`.
+  Suite is now 103 tests.
 - **`SkeletonModifier3D` migration — docs + Godot 4.7 investigation** —
   [docs/SKELETON_MODIFIER_MIGRATION.md](docs/SKELETON_MODIFIER_MIGRATION.md) records the
   rationale and as-built notes, grounded in a 4.7 investigation (4.7 leaves the

--- a/test/helpers/rig_harness.gd
+++ b/test/helpers/rig_harness.gd
@@ -73,7 +73,7 @@ func setup(p_tuning: RagdollTuning = null, p_profile: RagdollProfile = null, wit
 		ground = _build_ground()
 		add_child(ground)
 
-	skeleton = _build_skeleton()
+	skeleton = build_mixamo_skeleton()
 	add_child(skeleton)
 
 	# Sibling controllers, pre-configured BEFORE entering the tree so their
@@ -146,7 +146,10 @@ func skeleton_bone_world_origin(skeleton_bone: String) -> Vector3:
 	return (skeleton.global_transform * skeleton.get_bone_global_pose(idx)).origin
 
 
-func _build_skeleton() -> Skeleton3D:
+## Builds the synthetic Mixamo-named skeleton (21 bones, rest = standing pose).
+## Static so resource/validation tests can reuse the canonical skeleton without
+## assembling the whole physics rig.
+static func build_mixamo_skeleton() -> Skeleton3D:
 	var skel := Skeleton3D.new()
 	skel.name = "Skeleton3D"
 	var name_to_idx: Dictionary = {}

--- a/test/test_profile_validation.gd
+++ b/test/test_profile_validation.gd
@@ -1,0 +1,95 @@
+extends GutTest
+## Coverage for RagdollProfile.validate_against_skeleton — the inspector's
+## edit-time correctness gate. Uses the shared synthetic Mixamo skeleton built
+## by the runtime harness so the canonical profile round-trips cleanly.
+
+const RigHarness = preload("res://test/helpers/rig_harness.gd")
+
+var _skeleton: Skeleton3D
+
+
+func before_all():
+	_skeleton = RigHarness.build_mixamo_skeleton()
+
+
+func after_all():
+	if is_instance_valid(_skeleton):
+		_skeleton.free()
+
+
+func test_mixamo_default_validates_clean():
+	var p := RagdollProfile.create_mixamo_default()
+	var w := p.validate_against_skeleton(_skeleton)
+	assert_eq(w.size(), 0, "Mixamo default should validate clean against a Mixamo skeleton; got %s" % str(w))
+
+
+func test_missing_skeleton_bone_warns():
+	var p := RagdollProfile.create_mixamo_default()
+	for bd: BoneDefinition in p.bones:
+		if bd.rig_name == "Head":
+			bd.skeleton_bone = "no_such_bone"
+			break
+	var w := p.validate_against_skeleton(_skeleton)
+	var found := false
+	for warning: String in w:
+		if "no_such_bone" in warning:
+			found = true
+	assert_true(found, "A bone mapped to a missing skeleton bone should warn")
+
+
+func test_joint_referencing_undefined_rig_warns():
+	var p := RagdollProfile.create_mixamo_default()
+	var jd := JointDefinition.new()
+	jd.parent_rig = "Hips"
+	jd.child_rig = "GhostRig"
+	p.joints.append(jd)
+	var w := p.validate_against_skeleton(_skeleton)
+	var found := false
+	for warning: String in w:
+		if "GhostRig" in warning:
+			found = true
+	assert_true(found, "A joint referencing an undefined rig should warn")
+
+
+func test_role_referencing_undefined_rig_warns():
+	var p := RagdollProfile.create_mixamo_default()
+	p.head_rig = "NotABone"
+	var w := p.validate_against_skeleton(_skeleton)
+	var found := false
+	for warning: String in w:
+		if "NotABone" in warning:
+			found = true
+	assert_true(found, "A semantic role pointing at an undefined rig should warn")
+
+
+func test_missing_feet_warns_foot_ik():
+	var p := RagdollProfile.new()
+	var bd := BoneDefinition.new()
+	bd.rig_name = "Hips"
+	bd.skeleton_bone = "mixamorig_Hips"
+	p.bones.append(bd)
+	p.root_rig = "Hips"
+	p.foot_rigs = PackedStringArray()
+	p.left_leg_chain = PackedStringArray()
+	p.right_leg_chain = PackedStringArray()
+	var w := p.validate_against_skeleton(_skeleton)
+	var foot_warnings := 0
+	for warning: String in w:
+		if "Foot IK" in warning:
+			foot_warnings += 1
+	assert_true(foot_warnings >= 1, "Missing feet should produce foot-IK role warnings")
+
+
+func test_missing_intermediate_bone_warns():
+	var p := RagdollProfile.create_mixamo_default()
+	var entry := IntermediateBoneEntry.new()
+	entry.skeleton_bone = "ghost_intermediate"
+	entry.rig_body_a = "Spine"
+	entry.rig_body_b = "Chest"
+	p.intermediate_bones.append(entry)
+	var w := p.validate_against_skeleton(_skeleton)
+	var found := false
+	for warning: String in w:
+		if "ghost_intermediate" in warning:
+			found = true
+	assert_true(found, "A missing intermediate skeleton bone should warn")

--- a/test/test_profile_validation.gd.uid
+++ b/test/test_profile_validation.gd.uid
@@ -1,0 +1,1 @@
+uid://c3pdkpngdv3la

--- a/test/test_skeleton_detector.gd
+++ b/test/test_skeleton_detector.gd
@@ -1,5 +1,7 @@
 extends GutTest
 
+const RigHarness = preload("res://test/helpers/rig_harness.gd")
+
 
 var _mixamo_bones := PackedStringArray([
 	"mixamorig_Hips", "mixamorig_Spine", "mixamorig_Spine1", "mixamorig_Spine2",
@@ -111,3 +113,65 @@ func test_proportions_table_hands_have_depth_is_length():
 	var hand_r: Dictionary = SkeletonDetector.BONE_PROPORTIONS["Hand_R"]
 	assert_true(hand_l.get("depth_is_length", false), "Hand_L should have depth_is_length")
 	assert_true(hand_r.get("depth_is_length", false), "Hand_R should have depth_is_length")
+
+
+# --- create_collision_shape: single source of truth for box/capsule/sphere ---
+
+func test_create_collision_shape_box():
+	var bd := BoneDefinition.new()
+	bd.shape_type = "box"
+	bd.box_size = Vector3(0.3, 0.2, 0.25)
+	var col: CollisionShape3D = autofree(SkeletonDetector.create_collision_shape(bd))
+	assert_true(col.shape is BoxShape3D, "box shape_type yields a BoxShape3D")
+	assert_eq((col.shape as BoxShape3D).size, Vector3(0.3, 0.2, 0.25))
+
+
+func test_create_collision_shape_capsule():
+	var bd := BoneDefinition.new()
+	bd.shape_type = "capsule"
+	bd.capsule_radius = 0.08
+	bd.capsule_height = 0.4
+	var col: CollisionShape3D = autofree(SkeletonDetector.create_collision_shape(bd))
+	assert_true(col.shape is CapsuleShape3D, "capsule shape_type yields a CapsuleShape3D")
+	var cap := col.shape as CapsuleShape3D
+	assert_almost_eq(cap.radius, 0.08, 0.0001)
+	assert_almost_eq(cap.height, 0.4, 0.0001)
+
+
+func test_create_collision_shape_sphere():
+	var bd := BoneDefinition.new()
+	bd.shape_type = "sphere"
+	bd.sphere_radius = 0.12
+	var col: CollisionShape3D = autofree(SkeletonDetector.create_collision_shape(bd))
+	assert_true(col.shape is SphereShape3D, "sphere shape_type yields a SphereShape3D")
+	assert_almost_eq((col.shape as SphereShape3D).radius, 0.12, 0.0001)
+
+
+# --- create_profile_from_skeleton: full generation pipeline (round-trip) ---
+
+func test_create_profile_from_skeleton_round_trips():
+	var skel: Skeleton3D = autofree(RigHarness.build_mixamo_skeleton())
+	var mapping := SkeletonDetector.detect_humanoid_bones(skel)
+	assert_eq(mapping.size(), 16, "synthetic Mixamo skeleton detects all 16 slots")
+	var profile := SkeletonDetector.create_profile_from_skeleton(skel, mapping)
+	assert_eq(profile.bones.size(), 16, "generated profile has 16 bodies")
+	assert_eq(profile.joints.size(), 15, "generated profile has 15 joints")
+	assert_eq(profile.root_bone, "mixamorig_Hips", "root_bone set from the Hips mapping")
+	assert_true(profile.intermediate_bones.size() >= 1, "intermediate bones (Spine1/Neck) detected")
+	# Round-trip: a generated profile must validate clean against its own skeleton.
+	var w := profile.validate_against_skeleton(skel)
+	assert_eq(w.size(), 0, "generated profile validates clean against its skeleton; got %s" % str(w))
+
+
+func test_create_profile_foot_shape_is_box_with_depth():
+	var skel: Skeleton3D = autofree(RigHarness.build_mixamo_skeleton())
+	var mapping := SkeletonDetector.detect_humanoid_bones(skel)
+	var profile := SkeletonDetector.create_profile_from_skeleton(skel, mapping)
+	var checked := false
+	for bd: BoneDefinition in profile.bones:
+		if bd.rig_name == "Foot_L":
+			checked = true
+			assert_eq(bd.shape_type, "box", "foot uses a box shape")
+			var col: CollisionShape3D = autofree(SkeletonDetector.create_collision_shape(bd))
+			assert_true((col.shape as BoxShape3D).size.z > 0.0, "foot box has positive toe-depth")
+	assert_true(checked, "Foot_L should be present in the generated profile")


### PR DESCRIPTION
Closes three load-bearing, **no-physics** paths that had zero coverage. Deterministic and fast — no flake risk.

## Added

- **`test_profile_validation.gd`** (new, +6) — `RagdollProfile.validate_against_skeleton`, the inspector's edit-time correctness gate (6 warning branches, previously untested):
  - clean Mixamo round-trip (0 warnings),
  - bone mapped to a missing skeleton bone,
  - joint referencing an undefined rig,
  - semantic role referencing an undefined rig,
  - absent feet → foot-IK role warnings,
  - missing intermediate skeleton bone.
- **`test_skeleton_detector.gd`** (+5) — the generation pipeline:
  - `create_collision_shape` for box / capsule / sphere (the single-source-of-truth shape factory used by the builder, baker, and partial path),
  - `create_profile_from_skeleton` — a full **16-body / 15-joint** round-trip whose generated profile re-validates **clean** against its own skeleton, with feet as boxes with positive toe-depth.

## Refactor

- `rig_harness._build_skeleton()` → `static RigHarness.build_mixamo_skeleton()` so the pure tests reuse the canonical synthetic Mixamo skeleton without assembling the physics rig. The runtime harness behaviour is unchanged.

## Validation

- Clean headless import + **103/103** GUT, **stable across 3 runs**.
- Collision-shape test nodes are `autofree`'d — no orphan nodes and no leaked Jolt shape RIDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)