### PR TITLE
test: close runtime lifecycle coverage gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,11 @@
   `SkeletonDetector.create_collision_shape` (box/capsule/sphere) + `create_profile_from_skeleton`
   (a 16-body/15-joint round-trip that re-validates clean) in `test_skeleton_detector.gd`. The
   synthetic-skeleton builder was promoted to a reusable `RigHarness.build_mixamo_skeleton()`.
-  Suite is now 103 tests.
+- **Runtime lifecycle test gaps closed** — budget slot release on `_exit_tree` (despawn
+  mid-ragdoll), the `PhysicsCollisionMonitor` connect/disconnect lifecycle (its `_exit_tree`
+  signal-leak fix), `queue_ragdoll`/`queue_persistent` pre-setup deferral, the `apply_hit`
+  per-frame debounce, and a `SkeletonModifier3D` roll-back assertion (outside `skeleton_updated`
+  the skeleton reads the clean animation pose, not the physics body). Suite is now 108 tests.
 - **`SkeletonModifier3D` migration — docs + Godot 4.7 investigation** —
   [docs/SKELETON_MODIFIER_MIGRATION.md](docs/SKELETON_MODIFIER_MIGRATION.md) records the
   rationale and as-built notes, grounded in a 4.7 investigation (4.7 leaves the

--- a/test/test_budget.gd
+++ b/test/test_budget.gd
@@ -101,3 +101,18 @@ func test_persistent_bypasses_cap():
 	h.controller.set_persistent(true)
 	assert_eq(h.controller.get_state(), ActiveRagdollController.State.PERSISTENT,
 		"set_persistent (death/knockdown) ignores the budget")
+
+
+# ── Slot release on removal (despawn mid-ragdoll) ────────────────────────────
+
+func test_exit_tree_releases_budget_slot():
+	var h = await _spawn(_fast_tuning())
+	var mgr = _add_manager(1)
+	_hit(h)
+	assert_eq(mgr.get_active_ragdoll_count(), 1, "slot held during ragdoll")
+	# Despawn the character mid-ragdoll (e.g. removing a dead enemy). The
+	# controller's _exit_tree must release its slot or the budget leaks.
+	remove_child(h)
+	await get_tree().process_frame
+	assert_eq(mgr.get_active_ragdoll_count(), 0,
+		"removing the character mid-ragdoll releases its budget slot")

--- a/test/test_collision_monitor.gd
+++ b/test/test_collision_monitor.gd
@@ -1,0 +1,39 @@
+extends GutTest
+## Coverage for the optional PhysicsCollisionMonitor — its connect/disconnect
+## lifecycle, including the _exit_tree signal-leak fix (it must drop its
+## body_entered connections and reset contact_monitor when removed, so it does
+## not leak connections to rig bodies that outlive it).
+
+const RigHarness := preload("res://test/helpers/rig_harness.gd")
+
+
+func _spawn():
+	var h = RigHarness.new()
+	add_child_autoqfree(h)
+	var t := RagdollTuning.create_default()
+	t.foot_ik_enabled = false
+	h.setup(t, null, true)
+	var ok: bool = await h.await_ready(40)
+	assert_true(ok, "Kickback setup completed")
+	return h
+
+
+func test_monitor_connects_and_disconnects_cleanly():
+	var h = await _spawn()
+	var foot: RigidBody3D = h.get_body("Foot_L")
+	var base_conns := foot.body_entered.get_connections().size()
+
+	var mon := PhysicsCollisionMonitor.new()
+	h.add_child(mon)  # sibling of KickbackCharacter — it auto-discovers the rig
+	await get_tree().process_frame  # let _ready + _connect_to_bodies run
+
+	assert_true(foot.contact_monitor, "monitor enables contact_monitor on rig bodies")
+	assert_gt(foot.body_entered.get_connections().size(), base_conns,
+		"monitor added a body_entered connection to the rig bodies")
+
+	mon.free()
+	await get_tree().process_frame
+
+	assert_false(foot.contact_monitor, "_exit_tree restores contact_monitor = false")
+	assert_eq(foot.body_entered.get_connections().size(), base_conns,
+		"_exit_tree disconnects body_entered (no leaked connection to the freed monitor)")

--- a/test/test_collision_monitor.gd.uid
+++ b/test/test_collision_monitor.gd.uid
@@ -1,0 +1,1 @@
+uid://dbqnr4sx0hput

--- a/test/test_runtime_rig.gd
+++ b/test/test_runtime_rig.gd
@@ -159,6 +159,17 @@ func test_skeleton_sync_follows_physics_during_ragdoll():
 		assert_lt(float(diffs.get(pair[0], 999.0)), 0.06,
 			"skeleton bone '%s' follows its physics body via the modifier" % pair[0])
 
+	# Roll-back invariant: OUTSIDE the skeleton_updated callback, the skeleton's
+	# queryable pose is the clean (rolled-back) animation pose — NOT the fallen
+	# physics body. This is exactly what keeps the spring's get_bone_pose() target
+	# uncontaminated (no feedback loop).
+	var hips_idx := skel.find_bone("mixamorig_Hips")
+	var hips_bone_world := (skel.global_transform * skel.get_bone_global_pose(hips_idx)).origin
+	assert_gt(hips_bone_world.y, 0.7,
+		"outside skeleton_updated the hips bone reads the rolled-back animation pose (~rest height)")
+	assert_gt(hips_bone_world.distance_to(hips.global_position), 0.1,
+		"the rolled-back pose differs from the fallen physics body — modifier rollback is working")
+
 
 # ── Coordinator facade + balance ────────────────────────────────────────────
 
@@ -183,3 +194,51 @@ func test_anticipate_threat_emits_signal():
 	h.character.anticipate_threat(Vector3.FORWARD, 0.8)
 	assert_signal_emitted(h.controller, "threat_anticipated",
 		"anticipate_threat routes through to the controller signal")
+
+
+# ── Spawn-time queue API (deferral until setup_complete) ─────────────────────
+
+func test_queue_ragdoll_before_setup_defers():
+	var h = RigHarness.new()
+	add_child_autoqfree(h)
+	h.setup(_core_tuning(), null, true)
+	assert_false(h.character.is_setup_complete(), "not yet set up immediately after setup()")
+	h.character.queue_ragdoll()  # queued before the physics rig exists
+	var ok: bool = await h.await_ready(40)
+	assert_true(ok, "setup completed")
+	assert_eq(h.controller.get_state(), ActiveRagdollController.State.RAGDOLL,
+		"queue_ragdoll fired on setup_complete")
+
+
+func test_queue_persistent_before_setup_defers():
+	var h = RigHarness.new()
+	add_child_autoqfree(h)
+	h.setup(_core_tuning(), null, true)
+	h.character.queue_persistent()
+	var ok: bool = await h.await_ready(40)
+	assert_true(ok, "setup completed")
+	assert_eq(h.controller.get_state(), ActiveRagdollController.State.PERSISTENT,
+		"queue_persistent fired on setup_complete")
+
+
+# ── apply_hit per-frame debounce ─────────────────────────────────────────────
+
+func test_apply_hit_debounces_same_body_same_frame():
+	var h = await _spawn()
+	var head: RigidBody3D = h.get_body("Head")
+	var impact := ImpactProfile.new()
+	impact.base_impulse = 5.0
+	impact.impulse_transfer_ratio = 0.3
+	impact.ragdoll_probability = 0.0   # deterministic — never random-ragdoll
+	impact.strength_reduction = 0.5
+	impact.strength_spread = 0
+	impact.recovery_rate = 1.0
+	# Two hits on the same body with NO frame advance between them.
+	h.controller.apply_hit(head, Vector3.FORWARD, head.global_position, impact)
+	var after_first: float = h.spring.get_bone_strength("Head")
+	h.controller.apply_hit(head, Vector3.FORWARD, head.global_position, impact)
+	var after_second: float = h.spring.get_bone_strength("Head")
+	assert_lt(after_first, h.spring.get_base_strength("Head"),
+		"first hit reduced strength (guards against a trivially-passing test)")
+	assert_almost_eq(after_second, after_first, 0.0001,
+		"a second same-frame hit on the same body is debounced — no extra reduction")


### PR DESCRIPTION
Harness-driven coverage for load-bearing lifecycle paths that were untested or only hit their trivial branch.

## Added / strengthened

- **`test_budget.gd`** — budget slot released on the controller's `_exit_tree` (despawning a character mid-ragdoll). A real leak vector; the existing suite only released a slot via the recovery path.
- **`test_collision_monitor.gd`** (new) — `PhysicsCollisionMonitor` connect/disconnect lifecycle: it enables `contact_monitor` + connects `body_entered` on the rig bodies, and on `_exit_tree` it disconnects and resets them (the signal-leak fix — no dangling connection to a freed monitor).
- **`test_runtime_rig.gd`**:
  - `queue_ragdoll` / `queue_persistent` called **before** setup defer and fire on `setup_complete` (previously only the already-complete branch ran).
  - `apply_hit` per-frame debounce — a second same-frame hit on the same body is a no-op (the RID+frame guard that prevents `body_entered` feedback loops).
  - **Roll-back assertion** on the `SkeletonModifier3D` sync: outside `skeleton_updated`, `get_bone_global_pose` returns the clean (rolled-back) animation pose, not the fallen physics body — the invariant that keeps the spring's `get_bone_pose()` target uncontaminated.

## Validation

- Clean headless import + **108/108** GUT, **stable across 4 runs**, no orphan nodes or leaked RIDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)