### PR TITLE
fix: resolve apply_hit rig name from the builder map, not body.name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,11 @@
   hardcoded `Foot_L`/`UpperLeg_L`/… names, matching `RagdollProfile.validate_against_skeleton`.
   Non-Mixamo rigs that set the role fields no longer get spurious "foot_ik requires 'Foot_L'"
   warnings. (Completes the PR #62 de-hardcoding, which missed this one validator.)
+- **`apply_hit` resolves the rig name from the builder's body map** instead of trusting
+  `body.name`. If Godot suffix-renames a body on a node-name collision, or a baked rig's node
+  name differs from its `kickback_rig_name` metadata, hits previously no-op'd the strength
+  logic silently (impulse still applied, but no reaction). Now the hit affects the correct
+  bone, and a body that isn't a registered rig body warns and is ignored.
 
 ### Changed
 - **Budget hard cap** — `KickbackManager` (default 5 slots, discovered via the

--- a/addons/kickback/active_ragdoll_controller.gd
+++ b/addons/kickback/active_ragdoll_controller.gd
@@ -414,6 +414,16 @@ func apply_hit(body: RigidBody3D, hit_dir: Vector3, hit_pos: Vector3, profile: I
 		return
 	_hit_guard_bodies[body_rid] = true
 
+	# Resolve the rig name from the builder's body map rather than trusting
+	# body.name (Godot may suffix-rename on a node-name collision, and a baked rig
+	# keys bodies by metadata, not node name). A body that isn't a registered rig
+	# body is not part of this ragdoll — warn and ignore rather than silently no-op
+	# the strength logic.
+	var rig_name := _rig_name_for_body(body)
+	if rig_name.is_empty():
+		push_warning("ActiveRagdollController.apply_hit: '%s' is not a registered rig body — ignoring." % body.name)
+		return
+
 	# Hit streak: rapid consecutive hits escalate
 	var now := Time.get_ticks_msec() / 1000.0
 	if now - _last_hit_time < _tuning.rapid_fire_window:
@@ -470,13 +480,13 @@ func apply_hit(body: RigidBody3D, hit_dir: Vector3, hit_pos: Vector3, profile: I
 	pain_changed.emit(_pain)
 
 	if _state == State.STAGGER:
-		_handle_stagger_hit(body, hit_dir, effective_reduction, profile)
+		_handle_stagger_hit(rig_name, hit_dir, effective_reduction, profile)
 	else:
-		_handle_normal_hit(body, hit_dir, effective_reduction, profile)
+		_handle_normal_hit(rig_name, hit_dir, effective_reduction, profile)
 
 
-func _handle_stagger_hit(body: RigidBody3D, hit_dir: Vector3, effective_reduction: float, profile: ImpactProfile) -> void:
-	_reduce_strength(body.name, effective_reduction, profile.strength_spread)
+func _handle_stagger_hit(rig_name: String, hit_dir: Vector3, effective_reduction: float, profile: ImpactProfile) -> void:
+	_reduce_strength(rig_name, effective_reduction, profile.strength_spread)
 	_spring.recovery_rate = profile.recovery_rate
 	var boosted_prob := profile.ragdoll_probability * _tuning.stagger_ragdoll_bonus
 	# Hard cap: if the budget denies the slot, fall through to extend the stagger
@@ -486,11 +496,11 @@ func _handle_stagger_hit(body: RigidBody3D, hit_dir: Vector3, effective_reductio
 	else:
 		_stagger_elapsed = 0.0  # Extend stagger
 		_stagger_hit_dir = hit_dir
-		hit_absorbed.emit(body.name, _spring.get_bone_strength(body.name))
+		hit_absorbed.emit(rig_name, _spring.get_bone_strength(rig_name))
 
 
-func _handle_normal_hit(body: RigidBody3D, hit_dir: Vector3, effective_reduction: float, profile: ImpactProfile) -> void:
-	_reduce_strength(body.name, effective_reduction, profile.strength_spread)
+func _handle_normal_hit(rig_name: String, hit_dir: Vector3, effective_reduction: float, profile: ImpactProfile) -> void:
+	_reduce_strength(rig_name, effective_reduction, profile.strength_spread)
 	_spring.recovery_rate = profile.recovery_rate
 
 	# Ragdoll check: dice roll + pain-driven deterministic escalation
@@ -519,8 +529,8 @@ func _handle_normal_hit(body: RigidBody3D, hit_dir: Vector3, effective_reduction
 		# Reaction pulse for sub-stagger hits (visible micro-wobble)
 		var pulse_intensity := effective_reduction * _tuning.reaction_pulse_strength
 		if pulse_intensity > 0.01:
-			_apply_reaction_pulse(body.name, pulse_intensity, profile.strength_spread)
-		hit_absorbed.emit(body.name, _spring.get_bone_strength(body.name))
+			_apply_reaction_pulse(rig_name, pulse_intensity, profile.strength_spread)
+		hit_absorbed.emit(rig_name, _spring.get_bone_strength(rig_name))
 
 
 # ── Public API ──────────────────────────────────────────────────────────────
@@ -1079,6 +1089,17 @@ func _release_ragdoll_slot() -> void:
 		if _manager and is_instance_valid(_manager):
 			_manager.release_active_ragdoll()
 		_holds_ragdoll_slot = false
+
+
+## Resolves the rig name for a hit body via the builder's body map, rather than
+## trusting body.name (Godot may suffix-rename on a node-name collision; a baked
+## rig keys bodies by metadata). Returns "" if the body isn't a registered rig body.
+func _rig_name_for_body(body: RigidBody3D) -> String:
+	var bodies := _rig_builder.get_bodies()
+	for candidate: String in bodies:
+		if bodies[candidate] == body:
+			return candidate
+	return ""
 
 
 func _apply_directional_bracing(hit_dir: Vector3) -> void:

--- a/test/test_runtime_rig.gd
+++ b/test/test_runtime_rig.gd
@@ -242,3 +242,22 @@ func test_apply_hit_debounces_same_body_same_frame():
 		"first hit reduced strength (guards against a trivially-passing test)")
 	assert_almost_eq(after_second, after_first, 0.0001,
 		"a second same-frame hit on the same body is debounced — no extra reduction")
+
+
+func test_apply_hit_resolves_rig_name_after_body_rename():
+	var h = await _spawn()
+	var chest: RigidBody3D = h.get_body("Chest")
+	var before: float = h.spring.get_bone_strength("Chest")
+	# Simulate a Godot node-name collision rename: the node is no longer named
+	# "Chest", but the builder's body map still keys it as the Chest rig.
+	chest.name = "Chest@@2"
+	var impact := ImpactProfile.new()
+	impact.base_impulse = 5.0
+	impact.impulse_transfer_ratio = 0.3
+	impact.ragdoll_probability = 0.0
+	impact.strength_reduction = 0.5
+	impact.strength_spread = 0
+	impact.recovery_rate = 1.0
+	h.controller.apply_hit(chest, Vector3.FORWARD, chest.global_position, impact)
+	assert_lt(h.spring.get_bone_strength("Chest"), before,
+		"apply_hit resolves the rig via the builder map — the right bone weakens even after a body rename")


### PR DESCRIPTION
## Why

`ActiveRagdollController.apply_hit` keyed strength reduction, reaction pulses, and the `hit_absorbed` signal off **`body.name`**. That holds only while a `RigidBody3D`'s node name equals its rig name — but:

- Godot **suffix-renames** on a node-name collision (`Head` → `@Head@2`), and
- a **baked rig** keys bodies by the `kickback_rig_name` metadata, not the node name.

In those cases `_reduce_strength("@Head@2", …)` looked up a non-existent rig and silently no-op'd — the impulse still applied, so the hit *looked* like it did nothing.

## Fix

Resolve the rig name once via `_rig_name_for_body()` (reverse lookup in the builder's `get_bodies()` map) and thread it through `_handle_normal_hit` / `_handle_stagger_hit` (which no longer take the body). Behaviour is **identical** to `body.name` in the normal case. A body that isn't a registered rig body now `push_warning`s and is ignored rather than half-reacting (applying impulse but no reaction).

## Test

`test_apply_hit_resolves_rig_name_after_body_rename` — renames a body node, then asserts the hit still weakens the *correct* bone. Fails on the old `body.name` code; passes now.

## Validation

Clean headless import + **109/109** GUT, stable across 3 runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)