### PR TITLE
fix: frame-rate-independent velocity spring (60 Hz-anchored)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,14 @@
   name differs from its `kickback_rig_name` metadata, hits previously no-op'd the strength
   logic silently (impulse still applied, but no reaction). Now the hit affects the correct
   bone, and a body that isn't a registered rig body warns and is ignored.
+- **Spring math is now frame-rate independent** — `SpringResolver` previously divided
+  corrections by `delta` and applied a constant per-tick blend weight, so the effective
+  stiffness (and the residual velocity that feeds damping and the velocity clamp) drifted
+  with the physics tick rate — stiffer at 120 Hz, mushier at 30 Hz, with all tuning
+  implicitly calibrated to 60 Hz. Velocity targets and blend weights are now normalized to a
+  60 Hz reference (`_fr_weight`): **bit-identical at 60 Hz** (existing tuning unchanged) and
+  convergence-stable at other tick rates. Stays velocity-based (not a PD rewrite). Resolves
+  the last "Still open" item in [ROADMAP.md](docs/ROADMAP.md).
 
 ### Changed
 - **Budget hard cap** — `KickbackManager` (default 5 slots, discovered via the

--- a/addons/kickback/spring_resolver.gd
+++ b/addons/kickback/spring_resolver.gd
@@ -2,7 +2,8 @@
 ## animation skeleton poses. Each frame, computes rotation/position error per
 ## bone and lerps rigid body velocities toward the correction, weighted by
 ## per-bone strength. Strength can be reduced on hit so physics wins temporarily,
-## then recovers over time.
+## then recovers over time. Corrections are normalized to a 60 Hz reference, so
+## the feel is frame-rate independent — bit-identical at 60 Hz, stable at 30/120.
 @icon("res://addons/kickback/icons/spring_resolver.svg")
 class_name SpringResolver
 extends Node
@@ -30,6 +31,10 @@ var _strip_root_motion: bool = true
 var _root_motion_bone: String = "Hips"
 
 const PROPERTY_THRESHOLD := 0.01
+## Spring tuning is calibrated at 60 Hz. Per-tick blend weights and velocity
+## targets are normalized to this reference so behaviour matches across physics
+## tick rates (and is bit-identical at 60 Hz). See [method _fr_weight].
+const _REFERENCE_HZ := 60.0
 
 
 func configure(tuning: RagdollTuning) -> void:
@@ -156,7 +161,7 @@ func _physics_process(delta: float) -> void:
 		if pin_injury > 0.0:
 			pin *= (1.0 - pin_injury * _tuning.injury_pin_impact)
 		var pos_error := target_xform.origin - current_xform.origin
-		body.linear_velocity = body.linear_velocity.lerp(pos_error / delta, pin)
+		body.linear_velocity = body.linear_velocity.lerp(pos_error * _REFERENCE_HZ, _fr_weight(pin, delta))
 
 		if body.angular_velocity.length_squared() > _max_angular_vel_sq:
 			body.angular_velocity = body.angular_velocity.normalized() * _tuning.max_angular_velocity
@@ -183,8 +188,18 @@ func _apply_angular_spring(body: RigidBody3D, target: Transform3D, current: Tran
 	if axis_raw.length_squared() < 0.0001 or angle < 0.001:
 		return
 
-	var target_vel := (axis_raw.normalized() * angle) / delta
-	body.angular_velocity = body.angular_velocity.lerp(target_vel, strength)
+	var target_vel := (axis_raw.normalized() * angle) * _REFERENCE_HZ
+	body.angular_velocity = body.angular_velocity.lerp(target_vel, _fr_weight(strength, delta))
+
+
+## Converts a 60 Hz-calibrated lerp weight into a frame-rate-independent weight for
+## the current physics step. The per-tick fraction is reparameterized so the
+## convergence rate per unit wall-clock time stays constant across tick rates; at
+## 60 Hz this returns the weight unchanged (delta * _REFERENCE_HZ == 1). The weight
+## is clamped to [0, 1] (a >1 lerp would mean extrapolation, which has no stable
+## frame-rate-independent form).
+static func _fr_weight(weight: float, delta: float) -> float:
+	return 1.0 - pow(1.0 - clampf(weight, 0.0, 1.0), delta * _REFERENCE_HZ)
 
 
 func _get_pin_strength(rig_name: String) -> float:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -59,8 +59,11 @@ the remainder is tracked here.
   `set_bone_global_pose_override`. The modifier's per-frame pose roll-back keeps the spring's
   `get_bone_pose()` read clean (no feedback loop), and the node self-promotes under the
   skeleton at runtime. See [SKELETON_MODIFIER_MIGRATION.md](SKELETON_MODIFIER_MIGRATION.md).
+- ✅ **Spring math is frame-rate independent** — the velocity targets and per-tick blend
+  weights are normalized to a 60 Hz reference (`SpringResolver._fr_weight`), so reaction feel
+  no longer drifts with the physics tick rate. Bit-identical at 60 Hz; stable at 30/120.
 
 **Still open:**
 
-- **Spring math is implicitly 60 Hz-bound** — corrections are divided by `delta` with no
-  substepping awareness.
+- None currently tracked — the `0.3.x` hardening items are resolved. The next substantive
+  work is the `0.4.0` Self-Preservation layer (procedural stumble steps + arm bracing).

--- a/test/test_spring_math.gd
+++ b/test/test_spring_math.gd
@@ -1,0 +1,33 @@
+extends GutTest
+## Unit coverage for SpringResolver's frame-rate-independence reparameterization
+## (SpringResolver._fr_weight). The spring blends rigid-body velocities by a
+## per-tick weight; these assert the weight is 60 Hz-anchored (unchanged at the
+## reference rate) and that the resulting convergence is frame-rate independent.
+
+
+func test_fr_weight_identity_at_60hz():
+	# At the 60 Hz reference the weight is returned unchanged, so the existing
+	# tuning (calibrated at 60 Hz) is preserved bit-for-bit.
+	for w: float in [0.1, 0.25, 0.5, 0.65, 0.95]:
+		assert_almost_eq(SpringResolver._fr_weight(w, 1.0 / 60.0), w, 0.0001,
+			"weight %.2f is unchanged at 60 Hz" % w)
+
+
+func test_fr_weight_framerate_independent_decay():
+	# Over a fixed 1 s of wall-clock the fraction of error remaining must be the
+	# same regardless of tick rate. remaining = (1 - weight)^ticks.
+	var w := 0.5
+	var rem_30 := pow(1.0 - SpringResolver._fr_weight(w, 1.0 / 30.0), 30.0)
+	var rem_60 := pow(1.0 - SpringResolver._fr_weight(w, 1.0 / 60.0), 60.0)
+	var rem_120 := pow(1.0 - SpringResolver._fr_weight(w, 1.0 / 120.0), 120.0)
+	assert_almost_eq(rem_30, rem_60, 0.0001, "30 Hz converges like 60 Hz over 1 s")
+	assert_almost_eq(rem_120, rem_60, 0.0001, "120 Hz converges like 60 Hz over 1 s")
+
+
+func test_fr_weight_clamps_out_of_range():
+	# Defensive: a weight >= 1 must not produce NaN (a negative base raised to a
+	# fractional power). It clamps to a full snap.
+	assert_almost_eq(SpringResolver._fr_weight(1.0, 1.0 / 120.0), 1.0, 0.0001,
+		"weight 1.0 stays a full snap at any rate")
+	assert_false(is_nan(SpringResolver._fr_weight(1.5, 1.0 / 120.0)),
+		"out-of-range weight is clamped, not NaN")

--- a/test/test_spring_math.gd.uid
+++ b/test/test_spring_math.gd.uid
@@ -1,0 +1,1 @@
+uid://b1f6m0ta37h6r


### PR DESCRIPTION
**The headline correctness item from the audit.** ⚠️ Touches the physics-feel path — please give it an in-editor visual pass before merge.

## Problem

`SpringResolver` divided corrections by `delta` and blended velocity by a **constant per-tick weight**. Over a fixed wall-clock time you apply that weight `tick_rate` times, so the effective stiffness — and the residual velocity that then feeds the strength-scaled damping and the `max_angular/linear_velocity` clamp — scaled with the physics tick rate: **stiffer/twitchier at 120 Hz, mushier at 30 Hz**, with all tuning implicitly calibrated to 60 Hz. The plugin advertises "Godot 4.7+" with no tick-rate requirement.

## Fix (stays velocity-based — not a PD rewrite)

Normalize **both** the velocity target and the blend weight to a 60 Hz reference:

```gdscript
static func _fr_weight(weight, delta):
    return 1.0 - pow(1.0 - clampf(weight, 0.0, 1.0), delta * _REFERENCE_HZ)  # _REFERENCE_HZ = 60
```

At 60 Hz, `delta * 60 == 1`, so `_fr_weight` is the **identity** and the velocity target `error * 60 == error / delta` — i.e. **bit-identical to the old behaviour at the default tick rate** (existing tuning unchanged). At other rates the convergence per unit wall-clock time is constant. I deliberately did *not* rewrite the spring into a force/torque PD controller — that would contradict the documented velocity-based architecture.

## Validation

- **112/112 GUT, stable across 4 runs.** Crucially, the **109 pre-existing physics tests pass unchanged** (springs-hold-against-gravity, ragdoll, recovery, foot-IK) — direct evidence the 60 Hz feel is preserved.
- **`test_spring_math.gd`** (new, +3) proves the math: identity at 60 Hz, frame-rate-independent decay at 30/60/120, and out-of-range weights clamp (no NaN).
- Clean scene-smoke (0 errors, 150 frames) on `demo`, `euphoria_showcase`, `shooting_range`.
- Resolves the last **Still open** item in `ROADMAP.md`.

## 🔬 Visual review checklist (please)

1. **60 Hz (default):** reactions should look **exactly as before** — same stagger wobble, ragdoll, recovery feel. (The math says identical; confirm no perceptible change.)
2. **120 Hz** (`Project Settings → Physics → Common → Physics Ticks/Second = 120`): characters should *no longer* feel stiffer/twitchier than 60 Hz.
3. **30 Hz:** should *no longer* feel noticeably mushier/laggier than 60 Hz.

`euphoria_showcase.tscn` is the best scene to feel it (stagger sway + active resistance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)