### PR TITLE
fix: harden the partial-ragdoll path (race + UAF) + first tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,14 @@
   name differs from its `kickback_rig_name` metadata, hits previously no-op'd the strength
   logic silently (impulse still applied, but no reaction). Now the hit affects the correct
   bone, and a body that isn't a registered rig body warns and is ignored.
+- **Partial-ragdoll path hardened** — `PartialRagdollController` (the standalone
+  `PhysicalBoneSimulator3D` mode). A re-hit during the hold window used to fall through and
+  spawn a second, competing reaction coroutine (overlapping simulate/stop + blend), and a hit
+  on a character despawned mid-reaction could dereference the freed simulator. Reactions are now
+  tracked by a generation counter (a newer hit cleanly supersedes the in-flight one) and bail
+  via `_is_current()` after each await; `_exit_tree` cancels the blend. Adds the first automated
+  coverage for this mode (`test_partial_ragdoll.gd`): chain selection (children + parent, root
+  excluded), the react→hold→blend lifecycle, re-hit settling, and despawn-mid-reaction safety.
 
 ### Changed
 - **Budget hard cap** — `KickbackManager` (default 5 slots, discovered via the

--- a/addons/kickback/partial_ragdoll_controller.gd
+++ b/addons/kickback/partial_ragdoll_controller.gd
@@ -27,6 +27,12 @@ var _skeleton: Skeleton3D
 var _bone_map: Dictionary  # bone_name (String) → PhysicalBone3D
 var _active_tween: Tween
 var _is_reacting: bool = false
+## Monotonic reaction id. Every hit bumps it, so an in-flight reaction coroutine
+## from a prior hit bails on its next resume (see [method _is_current]). This is
+## what prevents the hold-window race where a second hit used to spawn a competing
+## coroutine.
+var _generation: int = 0
+var _exiting: bool = false
 var _profile: RagdollProfile
 var _tuning: RagdollTuning
 
@@ -62,28 +68,33 @@ func _build_bone_map() -> void:
 
 
 func apply_hit(event: HitEvent) -> void:
+	if not is_instance_valid(_simulator):
+		return
 	var chain := _get_bone_chain(event.hit_bone_name)
 	if chain.is_empty():
 		push_warning("PartialRagdollController: bone '%s' not part of PhysicalBoneSimulator3D — partial ragdoll hit ignored" % event.hit_bone_name)
 		return
 
-	# If already reacting during blend-out, extend instead of full restart.
-	# Killing the tween abandons the old _blend_out() coroutine's await — this is
-	# safe because _is_reacting stays true throughout, and a new blend-out takes over.
+	# Re-hit DURING the blend-out tween: extend smoothly without stopping the
+	# simulation (no snap). Bump the generation so the abandoned blend coroutine
+	# stays bailed, apply the extra impulse, and re-blend from the current influence.
 	if _is_reacting and _active_tween and _active_tween.is_valid():
 		_active_tween.kill()
-		# Apply additional impulse to the already-simulating bones
-		if event.hit_bone:
-			var local_offset := event.hit_bone.to_local(event.hit_position)
-			event.hit_bone.apply_impulse(event.hit_direction * event.impulse_magnitude, local_offset)
-		# Restart blend-out from current influence
-		_blend_out()
+		_active_tween = null
+		_apply_impulse(event)
+		_generation += 1
+		_blend_out(_generation)
 		return
 
-	# Fresh reaction
+	# Fresh hit, OR a re-hit during the hold / pre-simulation window (no live tween).
+	# Bumping the generation makes any in-flight reaction coroutine from a prior hit
+	# bail on its next resume — the fix for the hold-window race where the old code
+	# fell through here and spawned a second, competing coroutine.
+	_generation += 1
+	_set_reacting(true)
 	_simulator.physical_bones_stop_simulation()
 	_simulator.influence = 1.0
-	_run_reaction(event, chain)
+	_run_reaction(event, chain, _generation)
 
 
 func _get_bone_chain(bone_name: String) -> PackedStringArray:
@@ -114,32 +125,40 @@ func _collect_children(bone_idx: int, chain: PackedStringArray) -> void:
 		_collect_children(child_idx, chain)
 
 
-func _run_reaction(event: HitEvent, chain: PackedStringArray) -> void:
-	_set_reacting(true)
-
-	# Start partial simulation (deferred)
+func _run_reaction(event: HitEvent, chain: PackedStringArray, gen: int) -> void:
+	# Start partial simulation (deferred a frame so the simulator settles first).
 	await get_tree().physics_frame
+	if not _is_current(gen):
+		return
 	_simulator.physical_bones_start_simulation(chain)
 
-	# Apply impulse now that the bone is simulating
+	# Apply impulse now that the bones are simulating.
 	await get_tree().physics_frame
-	if event.hit_bone:
-		var local_offset := event.hit_bone.to_local(event.hit_position)
-		event.hit_bone.apply_impulse(event.hit_direction * event.impulse_magnitude, local_offset)
+	if not _is_current(gen):
+		return
+	_apply_impulse(event)
 
-	# Hold — let physics play out
+	_hold_then_blend(gen)
+
+
+func _hold_then_blend(gen: int) -> void:
+	# Hold — let physics play out — then blend back to animation.
 	await get_tree().create_timer(hold_time).timeout
+	if not _is_current(gen):
+		return
+	_blend_out(gen)
 
-	_blend_out()
 
-
-func _blend_out() -> void:
+func _blend_out(gen: int) -> void:
 	_active_tween = create_tween()
 	_active_tween.tween_property(_simulator, "influence", 0.0, blend_duration).set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_QUAD)
 	await _active_tween.finished
+	if not _is_current(gen):
+		return
 
 	_simulator.physical_bones_stop_simulation()
 	_simulator.influence = 1.0
+	_active_tween = null
 	_set_reacting(false)
 
 
@@ -151,3 +170,23 @@ func _set_reacting(value: bool) -> void:
 
 func is_reacting() -> bool:
 	return _is_reacting
+
+
+func _apply_impulse(event: HitEvent) -> void:
+	if event.hit_bone:
+		var local_offset := event.hit_bone.to_local(event.hit_position)
+		event.hit_bone.apply_impulse(event.hit_direction * event.impulse_magnitude, local_offset)
+
+
+## A reaction coroutine is stale if a newer hit superseded it (the generation was
+## bumped), the controller is leaving the tree, or the simulator was freed (the
+## character despawned mid-reaction). Stale coroutines bail instead of touching a
+## freed simulator.
+func _is_current(gen: int) -> bool:
+	return gen == _generation and not _exiting and is_instance_valid(_simulator)
+
+
+func _exit_tree() -> void:
+	_exiting = true
+	if _active_tween and _active_tween.is_valid():
+		_active_tween.kill()

--- a/test/test_partial_ragdoll.gd
+++ b/test/test_partial_ragdoll.gd
@@ -1,0 +1,121 @@
+extends GutTest
+## Coverage for the standalone Partial Ragdoll path (PhysicalBoneSimulator3D),
+## previously untested. Builds a synthetic Mixamo skeleton + a populated
+## PhysicalBoneSimulator3D + a PartialRagdollController, then exercises chain
+## selection and the react -> hold -> blend-out lifecycle, including the
+## re-hit and despawn-mid-reaction edge cases the harden pass fixed.
+
+const RigHarness := preload("res://test/helpers/rig_harness.gd")
+
+var _root: Node3D
+var _skeleton: Skeleton3D
+var _sim: PhysicalBoneSimulator3D
+var _ctrl: PartialRagdollController
+
+
+func before_each():
+	_root = Node3D.new()
+	add_child_autoqfree(_root)
+	_skeleton = RigHarness.build_mixamo_skeleton()
+	_root.add_child(_skeleton)
+	_sim = PhysicalBoneSimulator3D.new()
+	_sim.name = "PhysicalBoneSimulator3D"
+	_skeleton.add_child(_sim)
+	var mapping := SkeletonDetector.detect_humanoid_bones(_skeleton)
+	SkeletonDetector.populate_physical_bones(_skeleton, _sim, mapping, _root)
+	_sim.active = true
+
+	_ctrl = PartialRagdollController.new()
+	_ctrl.simulator_path = NodePath("../Skeleton3D/PhysicalBoneSimulator3D")
+	_ctrl.skeleton_path = NodePath("../Skeleton3D")
+	_ctrl.hold_time = 0.1
+	_ctrl.blend_duration = 0.15
+	_ctrl.configure(RagdollProfile.create_mixamo_default(), RagdollTuning.create_default())
+	_root.add_child(_ctrl)
+	await get_tree().process_frame  # let _ready build the bone map
+
+
+func _phys_bone(bone_name: String) -> PhysicalBone3D:
+	for c in _sim.get_children():
+		if c is PhysicalBone3D and (c as PhysicalBone3D).bone_name == bone_name:
+			return c
+	return null
+
+
+func _event(bone_name: String) -> HitEvent:
+	var e := HitEvent.new()
+	e.hit_bone_name = bone_name
+	e.hit_direction = Vector3.FORWARD
+	e.hit_position = Vector3.ZERO
+	e.impulse_magnitude = 3.0
+	e.hit_bone = _phys_bone(bone_name)
+	return e
+
+
+# ── Chain selection ──────────────────────────────────────────────────────────
+
+func test_chain_includes_bone_children_and_parent():
+	var chain := _ctrl._get_bone_chain("mixamorig_LeftForeArm")
+	assert_has(chain, "mixamorig_LeftForeArm", "the hit bone itself")
+	assert_has(chain, "mixamorig_LeftHand", "the child bone")
+	assert_has(chain, "mixamorig_LeftArm", "the parent bone")
+
+
+func test_chain_excludes_root():
+	# Upper-leg's parent is the Hips (root). The root must never be pulled into
+	# the simulated chain (it anchors the character).
+	var chain := _ctrl._get_bone_chain("mixamorig_LeftUpLeg")
+	assert_has(chain, "mixamorig_LeftUpLeg", "the hit bone")
+	assert_has(chain, "mixamorig_LeftLeg", "the child")
+	assert_does_not_have(chain, "mixamorig_Hips", "root excluded from the chain")
+
+
+func test_unmapped_bone_is_ignored():
+	_ctrl.apply_hit(_event("no_such_bone"))
+	assert_false(_ctrl.is_reacting(), "a hit on an unmapped bone is a no-op")
+
+
+# ── React -> hold -> blend-out lifecycle ─────────────────────────────────────
+
+func test_react_then_recovers():
+	_ctrl.apply_hit(_event("mixamorig_LeftForeArm"))
+	assert_true(_ctrl.is_reacting(), "reacting immediately after the hit")
+	# The first state_changed(true) already fired synchronously; wait for the
+	# blend-out's state_changed(false).
+	var fired: bool = await wait_for_signal(_ctrl.state_changed, 5.0)
+	assert_true(fired, "blend-out completed and emitted state_changed")
+	assert_false(_ctrl.is_reacting(), "no longer reacting after blend-out")
+	assert_almost_eq(_sim.influence, 1.0, 0.01, "influence restored to 1.0 after blend-out")
+
+
+func test_rehit_during_reaction_settles():
+	# A second hit landing during the hold window used to fall through and spawn a
+	# SECOND, competing reaction coroutine (the race the generation counter fixes).
+	# The race is a visual glitch (dedup hides it from signal counts), so here we
+	# assert the deterministic part: the re-hit lifecycle still resolves cleanly to
+	# not-reacting with influence restored — it never hangs or strands the controller.
+	_ctrl.apply_hit(_event("mixamorig_LeftForeArm"))
+	await get_tree().physics_frame
+	await get_tree().physics_frame
+	_ctrl.apply_hit(_event("mixamorig_LeftForeArm"))  # re-hit mid-reaction
+	# Poll until settled (generous budget; timers/tweens advance with SceneTree time).
+	var settled := false
+	for i in 360:
+		await get_tree().process_frame
+		if not _ctrl.is_reacting():
+			settled = true
+			break
+	assert_true(settled, "re-hit reaction settles back to not-reacting")
+	assert_almost_eq(_sim.influence, 1.0, 0.01, "influence restored after the re-hit reaction")
+
+
+func test_exit_during_reaction_is_safe():
+	_ctrl.apply_hit(_event("mixamorig_LeftForeArm"))
+	await get_tree().physics_frame
+	# Despawn the whole character mid-reaction (common when a hit enemy is removed).
+	_root.queue_free()
+	# Let the abandoned coroutine's awaits resume across several frames — it must
+	# bail via _is_current() instead of touching the freed simulator.
+	for i in 20:
+		await get_tree().process_frame
+	assert_true(true, "freeing the character mid-reaction did not crash the pending coroutine")

--- a/test/test_partial_ragdoll.gd.uid
+++ b/test/test_partial_ragdoll.gd.uid
@@ -1,0 +1,1 @@
+uid://c0jpp30afkgxl


### PR DESCRIPTION
The partial-ragdoll mode (`PhysicalBoneSimulator3D`) is the least-exercised path and had **zero tests**; the audit found two real bugs in it. ⚠️ Touches a physics path — needs an in-editor visual pass (re-hit smoothness) before merge.

## Bugs fixed

1. **Re-hit during the HOLD window → coroutine race.** The re-entrancy guard only caught the blend-out phase (a live tween). During the hold (the `await`s before the tween is created), a second hit fell through to the *fresh reaction* branch — `physical_bones_stop_simulation()` mid-sim + a **second** `_run_reaction` coroutine racing the first (overlapping simulate/stop, double blend-out).
2. **Despawn mid-reaction → use-after-free.** The detached coroutines hold `await`s across ~0.5 s; freeing the character (and its simulator) meanwhile dereferenced the freed `_simulator`. The controller also lacked an `_exit_tree` (the only controller without one).

## Fix

A monotonic **generation counter**: every hit bumps it; each coroutine captures its generation and bails via `_is_current(gen)` after every `await`, so a newer hit cleanly supersedes the in-flight one — only one reaction is ever live. `_exit_tree` sets an exiting flag and kills the tween; `_is_current` also checks `is_instance_valid(_simulator)`. The smooth blend-out re-hit path is preserved.

## Tests — `test_partial_ragdoll.gd` (+6, first coverage of this mode)

Builds a synthetic skeleton + populated `PhysicalBoneSimulator3D` + controller and exercises: chain selection (hit bone + children + parent, **root excluded**; unmapped bone ignored), the react→hold→blend lifecycle (influence restored to 1), re-hit settling, and despawn-mid-reaction safety.

> Note: the re-hit *race* manifests as a visual snap, not a signal-count difference (`_set_reacting`'s change-guard dedups both code paths to one `state_changed(false)`), so the test asserts clean settling and the no-snap smoothness is left to the visual pass.

## Validation

Clean headless import + **115/115** GUT, stable across 4 runs, no orphans / leaked RIDs.

## 🔬 Visual review (please)

In `demo.tscn` (Active vs **Partial** side-by-side): shoot the partial character repeatedly (rapid re-hits) — the limb should re-react smoothly without a hard snap, and blend back to animation cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)