### PR TITLE
perf: cut per-frame allocations and redundant work on hot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,16 @@
   incl. a signal-time multi-bone sync assertion that exercises the write ordering + clean
   scene-smoke on all 8 demos); mesh-tracking polish verified in-editor.
 
+### Performance
+- **Per-frame allocation & redundant-work cleanup** — `SpringResolver.get_all_bone_names()`
+  now returns a list cached at init instead of rebuilding a `PackedStringArray` from
+  `_bones.keys()` on every call (it is read each physics frame by the controller, HUD, and
+  foot-IK across ~12 call sites; the key set is fixed once the rig is built). The controller
+  computes `_compute_balance_state()` once per stagger frame and shares it between active
+  resistance and the tip/recovery checks — it sums center-of-mass over every body and was
+  being computed twice per frame. `StrengthDebugHUD` disables `_process` while the overlay is
+  off (F3), so it does no per-frame redraw work until it is toggled on.
+
 ### Removed
 - Dead passive-tracking path in `SpringResolver` (springs are always active) and its 5
   unused tuning parameters (`spring_active_gravity`, `spring_active_angular_damp`,

--- a/addons/kickback/active_ragdoll_controller.gd
+++ b/addons/kickback/active_ragdoll_controller.gd
@@ -306,14 +306,18 @@ func _update_stagger(delta: float) -> void:
 		if _spring.get_bone_strength(rig_name) < floor_val:
 			_spring.set_bone_strength(rig_name, floor_val)
 
+	# Balance is read by both active resistance and the tip/recovery checks below.
+	# It sums CoM over every body, so compute it once per stagger frame and share
+	# it (bodies don't move between these reads — only spring strengths change).
+	var balance_state := _compute_balance_state()
+
 	# Active resistance: dynamic per-frame strength adjustment
-	_apply_active_resistance(delta)
+	_apply_active_resistance(delta, balance_state)
 
 	# Continuous sway force: fights springs to create visible wobble
 	_apply_stagger_sway(delta)
 
 	# Balance-informed stagger (only when foot support can actually be measured)
-	var balance_state := _compute_balance_state()
 	var balance: float = balance_state.balance_ratio
 	var has_support: bool = balance_state.has_support
 	balance_changed.emit(balance)
@@ -1150,13 +1154,12 @@ func _is_leg_bone(rig_name: String) -> bool:
 	return _leg_rig_set.has(rig_name)
 
 
-func _apply_active_resistance(delta: float) -> void:
+func _apply_active_resistance(delta: float, balance_state: Dictionary) -> void:
 	# Early exit if all resistance is disabled
 	if _tuning.resistance_counter_strength <= 0.0 and _tuning.resistance_core_ramp <= 0.0 and _tuning.resistance_leg_brace <= 0.0:
 		return
 
 	var bodies := _rig_builder.get_bodies()
-	var balance_state := _compute_balance_state()
 	var com: Vector3 = balance_state.com
 	var support_center: Vector3 = balance_state.support_center
 	var balance_ratio: float = balance_state.balance_ratio

--- a/addons/kickback/spring_resolver.gd
+++ b/addons/kickback/spring_resolver.gd
@@ -20,6 +20,7 @@ var _skeleton: Skeleton3D
 var _rig_builder: PhysicsRigBuilder
 var _active: bool = false
 var _bones: Dictionary = {}  # rig_name → {body, bone_idx, base_strength, strength}
+var _bone_names: PackedStringArray = PackedStringArray()  # cached _bones.keys(); stable after _init_bones()
 var _settle_timer: float = 0.0
 var _default_recovery_rate: float = 0.3
 var _target_overrides: Dictionary = {}  # rig_name → Transform3D (temporary blend targets)
@@ -88,6 +89,11 @@ func _init_bones() -> void:
 			"base_strength": base_str,
 			"strength": base_str,
 		}
+	# Cache the rig-name list once. The key set is fixed after init (only the
+	# per-bone values mutate), and get_all_bone_names() is hit every physics
+	# frame by the controller/HUD/foot-IK — returning the cached PackedStringArray
+	# avoids rebuilding it from _bones.keys() on each call.
+	_bone_names = PackedStringArray(_bones.keys())
 
 
 ## Returns the Skeleton3D used for animation target poses.
@@ -241,8 +247,10 @@ func get_base_strength(rig_name: String) -> float:
 
 
 ## Returns the rig names of all registered bones (e.g. "Hips", "Spine", "Head").
+## Cached at init (the key set is fixed once bones are built); callers must treat
+## the result as read-only.
 func get_all_bone_names() -> PackedStringArray:
-	return PackedStringArray(_bones.keys())
+	return _bone_names
 
 
 func get_default_recovery_rate() -> float:

--- a/addons/kickback/strength_debug_hud.gd
+++ b/addons/kickback/strength_debug_hud.gd
@@ -47,12 +47,16 @@ const DETAIL_LABELS := ["OFF", "DOTS", "WIREFRAME", "FULL"]
 func _ready() -> void:
 	visible = false
 	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	# Starts off — no per-frame redraw work until the overlay is toggled on (F3).
+	set_process(false)
 
 
 func _unhandled_input(event: InputEvent) -> void:
 	if event is InputEventKey and event.pressed and event.keycode == KEY_F3:
 		_detail_level = (_detail_level + 1) % 4
 		visible = _detail_level > 0
+		# Only run _process (per-frame queue_redraw) while the overlay is visible.
+		set_process(_detail_level > 0)
 		if _detail_level > 0 and not _discovered:
 			_discover_targets()
 		queue_redraw()


### PR DESCRIPTION
## Summary

Three behavior-preserving hot-path cleanups for the 0.3.x finalization gate. No feel changes — these only remove redundant per-frame work.

### 1. `SpringResolver.get_all_bone_names()` — cache the rig-name list
The getter rebuilt a `PackedStringArray` from `_bones.keys()` on **every call**, and it's read every physics frame across ~12 call sites (controller stagger/recovery/ragdoll loops, foot-IK, HUD). The bone key set is fixed once `_init_bones()` runs, so it's now cached there and the getter returns the cached array (callers already only iterate it read-only).

### 2. `ActiveRagdollController` — compute balance once per stagger frame
`_compute_balance_state()` sums center-of-mass over every rig body. During stagger it was computed **twice per frame** — once inside `_apply_active_resistance()` and once in `_update_stagger()`. Bodies don't move between those two reads (only spring strengths change), so the result is identical; it's now computed once and passed in.

### 3. `StrengthDebugHUD` — disable `_process` while off
The overlay starts off and is toggled with F3, but `_process` ran every frame regardless. It now `set_process(false)` at `_ready()` and toggles processing with the detail level, so there's zero per-frame cost until shown.

## Validation
- Headless import: clean (exit 0, no errors)
- GUT suite: **112/112**, 3× stable
- Scene-smoke (`--quit-after 150`): clean on `euphoria_showcase` (exercises the active-resistance/stagger path) and `demo`

## Visual sign-off
Per the gate process, this wants a quick in-editor spot-check (stagger feel unchanged, F3 HUD still toggles correctly) before merge — though the changes are allocation/scheduling only and shouldn't alter feel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)