### PR TITLE
chore: standardize environment collision on layer 1 everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,15 @@
   tool's node type changed (`Node` → `SkeletonModifier3D`). Validated headlessly (89 GUT tests
   incl. a signal-time multi-bone sync assertion that exercises the write ordering + clean
   scene-smoke on all 8 demos); mesh-tracking polish verified in-editor.
+- **Collision layers standardized — environment is layer 1 everywhere** — `KickbackLayers.ENVIRONMENT_LAYER`
+  is now layer 1 (was 2), matching the foot-IK (`foot_ik_collision_mask`) and recovery
+  (`ground_raycast_mask`) ground-ray masks — which always defaulted to layer 1 — and the
+  `INTEGRATION.md` convention. All demo floors moved from layer 2 (and the `foot_ik_demo`
+  terrain from layer 3) to layer 1, so foot-IK and recovery raycasts now actually hit the
+  ground in every demo (they were silently missing it before; the rig still rested via body
+  collision). The shooting-range player moved to its own layer (3) and the thrown ball's mask
+  now references ground as layer 1. The setup-report dialog, `GODOT_CONSTRAINTS.md`, and
+  `STEP_BY_STEP.md` were updated to the same layer-1-environment scheme.
 
 ### Removed
 - Dead passive-tracking path in `SpringResolver` (springs are always active) and its 5

--- a/addons/kickback/kickback_layers.gd
+++ b/addons/kickback/kickback_layers.gd
@@ -18,6 +18,8 @@ const PARTIAL_RAGDOLL_LAYER := 1 << PARTIAL_RAGDOLL_BIT  # 16
 ## Combined mask matching either ragdoll layer (used by hit raycasts).
 const BOTH_RAGDOLL_MASK := ACTIVE_RAGDOLL_LAYER | PARTIAL_RAGDOLL_LAYER  # 24
 
-## Environment / world geometry that PhysicalBone3D bodies collide against. UI layer 2.
-const ENVIRONMENT_BIT := 1
-const ENVIRONMENT_LAYER := 1 << ENVIRONMENT_BIT          # 2
+## Environment / world geometry (floors, walls) that physics bodies collide
+## against and that foot-IK / recovery ground raycasts hit. UI layer 1 — Godot's
+## default body layer, matching foot_ik_collision_mask / ground_raycast_mask.
+const ENVIRONMENT_BIT := 0
+const ENVIRONMENT_LAYER := 1 << ENVIRONMENT_BIT          # 1

--- a/addons/kickback/kickback_plugin.gd
+++ b/addons/kickback/kickback_plugin.gd
@@ -233,7 +233,7 @@ func _show_setup_report(character_name: String, bone_mapping: Dictionary, node_c
 		report += "Skeleton: Using Mixamo defaults (auto-detection failed)\n\n"
 
 	report += "Collision Layers:\n"
-	report += "  Layer 2: Environment (ground raycasts during recovery)\n"
+	report += "  Layer 1: Environment (foot-IK + recovery ground raycasts)\n"
 	report += "  Layer 4: Active ragdoll bodies (RigidBody3D)\n"
 
 	report += "\nSignals (connect in your code to handle animations):\n"

--- a/demo/animated_npc.tscn
+++ b/demo/animated_npc.tscn
@@ -19,7 +19,7 @@ transform = Transform3D(0.866, -0.354, 0.354, 0, 0.707, 0.707, -0.5, -0.612, 0.6
 shadow_enabled = true
 
 [node name="Ground" type="StaticBody3D" parent="."]
-collision_layer = 2
+collision_layer = 1
 collision_mask = 0
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Ground"]

--- a/demo/demo.tscn
+++ b/demo/demo.tscn
@@ -19,7 +19,7 @@ transform = Transform3D(0.866, -0.354, 0.354, 0, 0.707, 0.707, -0.5, -0.612, 0.6
 shadow_enabled = true
 
 [node name="Ground" type="StaticBody3D" parent="." unique_id=2081362761]
-collision_layer = 2
+collision_layer = 1
 collision_mask = 0
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Ground" unique_id=1346268604]

--- a/demo/euphoria_showcase.tscn
+++ b/demo/euphoria_showcase.tscn
@@ -19,7 +19,7 @@ transform = Transform3D(0.866, -0.354, 0.354, 0, 0.707, 0.707, -0.5, -0.612, 0.6
 shadow_enabled = true
 
 [node name="Ground" type="StaticBody3D" parent="."]
-collision_layer = 2
+collision_layer = 1
 collision_mask = 0
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Ground"]

--- a/demo/foot_ik_demo.tscn
+++ b/demo/foot_ik_demo.tscn
@@ -69,7 +69,7 @@ transform = Transform3D(1, 0, 0, 0, 0.94, -0.342, 0, 0.342, 0.94, 0, 3, 8)
 
 [node name="GroundLeft" type="StaticBody3D" parent="." unique_id=696640374]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -6, -0.1, 1.25)
-collision_layer = 3
+collision_layer = 1
 collision_mask = 0
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="GroundLeft" unique_id=89624005]
@@ -81,7 +81,7 @@ shape = SubResource("Shape_GroundL")
 
 [node name="Step1" type="StaticBody3D" parent="." unique_id=2016308712]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3.5, 0.075, 1.25)
-collision_layer = 3
+collision_layer = 1
 collision_mask = 0
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Step1" unique_id=922588195]
@@ -93,7 +93,7 @@ shape = SubResource("Shape_Step1")
 
 [node name="Step2" type="StaticBody3D" parent="." unique_id=1059188893]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.3, 0.15, 1.25)
-collision_layer = 3
+collision_layer = 1
 collision_mask = 0
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Step2" unique_id=43794156]
@@ -105,7 +105,7 @@ shape = SubResource("Shape_Step2")
 
 [node name="Step3" type="StaticBody3D" parent="." unique_id=1477955755]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.1, 0.225, 1.25)
-collision_layer = 3
+collision_layer = 1
 collision_mask = 0
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Step3" unique_id=484387193]
@@ -117,7 +117,7 @@ shape = SubResource("Shape_Step3")
 
 [node name="Ramp" type="StaticBody3D" parent="." unique_id=780230453]
 transform = Transform3D(-0.9659, -0.2588, -8.742278e-08, -0.2588, 0.9659, 0, 8.444166e-08, 2.2625013e-08, -1, 0.5, 0.55, 1.25)
-collision_layer = 3
+collision_layer = 1
 collision_mask = 0
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Ramp" unique_id=1175852030]
@@ -129,7 +129,7 @@ shape = SubResource("Shape_Ramp")
 
 [node name="Plateau" type="StaticBody3D" parent="." unique_id=1287424013]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 3, 0.4, 1.25)
-collision_layer = 3
+collision_layer = 1
 collision_mask = 0
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Plateau" unique_id=511985218]
@@ -141,7 +141,7 @@ shape = SubResource("Shape_Plateau")
 
 [node name="GroundRight" type="StaticBody3D" parent="." unique_id=584297269]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 6, -0.1, 1.25)
-collision_layer = 3
+collision_layer = 1
 collision_mask = 0
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="GroundRight" unique_id=1117262187]

--- a/demo/shooting_range.gd
+++ b/demo/shooting_range.gd
@@ -212,7 +212,7 @@ func _throw_ball() -> void:
 	var ball := RigidBody3D.new()
 	ball.mass = BALL_MASS
 	ball.collision_layer = 2
-	ball.collision_mask = 10  # ground (layer 2) + active ragdoll (layer 4)
+	ball.collision_mask = 9  # ground (layer 1) + active ragdoll (layer 4)
 	ball.contact_monitor = true
 	ball.max_contacts_reported = 4
 	ball.physics_interpolation_mode = Node.PHYSICS_INTERPOLATION_MODE_ON

--- a/demo/shooting_range.tscn
+++ b/demo/shooting_range.tscn
@@ -22,7 +22,7 @@ transform = Transform3D(0.866, -0.354, 0.354, 0, 0.707, 0.707, -0.5, -0.612, 0.6
 shadow_enabled = true
 
 [node name="Ground" type="StaticBody3D" parent="."]
-collision_layer = 2
+collision_layer = 1
 collision_mask = 0
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Ground"]
@@ -34,8 +34,8 @@ shape = SubResource("WorldBoundary_1")
 
 [node name="Player" type="CharacterBody3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.9, 8)
-collision_layer = 1
-collision_mask = 2
+collision_layer = 3
+collision_mask = 1
 script = ExtResource("1_script")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Player"]

--- a/demo/signal_showcase.tscn
+++ b/demo/signal_showcase.tscn
@@ -19,7 +19,7 @@ transform = Transform3D(0.866, -0.354, 0.354, 0, 0.707, 0.707, -0.5, -0.612, 0.6
 shadow_enabled = true
 
 [node name="Ground" type="StaticBody3D" parent="."]
-collision_layer = 2
+collision_layer = 1
 collision_mask = 0
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Ground"]

--- a/demo/stress_test.tscn
+++ b/demo/stress_test.tscn
@@ -18,7 +18,7 @@ transform = Transform3D(0.866, -0.354, 0.354, 0, 0.707, 0.707, -0.5, -0.612, 0.6
 shadow_enabled = true
 
 [node name="Ground" type="StaticBody3D" parent="."]
-collision_layer = 2
+collision_layer = 1
 collision_mask = 0
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Ground"]

--- a/demo/tuning_playground.tscn
+++ b/demo/tuning_playground.tscn
@@ -19,7 +19,7 @@ transform = Transform3D(0.866, -0.354, 0.354, 0, 0.707, 0.707, -0.5, -0.612, 0.6
 shadow_enabled = true
 
 [node name="Ground" type="StaticBody3D" parent="."]
-collision_layer = 2
+collision_layer = 1
 collision_mask = 0
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Ground"]

--- a/docs/GODOT_CONSTRAINTS.md
+++ b/docs/GODOT_CONSTRAINTS.md
@@ -131,7 +131,7 @@ Recommended values for Mixamo Y Bot:
 ### Self-collision
 Set PhysicalBone3D `collision_mask` to include its own layer (layer 5) for
 inter-bone collision. Without this, limbs pass through each other.
-Mask = 18 (layer 2 environment + layer 5 self).
+Mask = 17 (layer 1 environment + layer 5 self).
 
 ### Damping
 Auto-generated bones have zero damping — ragdoll feels liquid. Add:
@@ -259,16 +259,19 @@ for typed node reference exports (`@export var x: Node3D`). Do NOT use it for
 
 ## Collision layers
 
-Use this layout:
-- Layer 1: Character controllers (CharacterBody3D)
-- Layer 2: Environment (StaticBody3D, terrain)
-- Layer 3: Props, dynamic objects
-- Layer 4: Ragdoll physics bodies (RigidBody3D from dual-skeleton)
-- Layer 5: PhysicalBone3D (partial ragdoll)
+Use this layout (matches `KickbackLayers` and the bundled demos):
+- Layer 1: Environment (StaticBody3D floors, walls, terrain) — foot-IK + recovery rays hit this
+- Layer 2: Projectiles / raycasts (e.g. the shooting-range ball)
+- Layer 3: Player / character controllers (CharacterBody3D)
+- Layer 4: Active ragdoll bodies (RigidBody3D)
+- Layer 5: Godot built-in ragdoll (PhysicalBone3D, comparison demo only)
 
-Ragdoll bodies (layer 4) should:
-- Collide with: layer 2 (environment), layer 3 (props), layer 4 (self — inter-bone collision)
-- NOT collide with: layer 1 (would conflict with CharacterBody3D)
+Active ragdoll bodies default to `collision_layer` 4 and `collision_mask` 15
+(collide with layers 1–4): environment (1), projectiles (2), characters (3), and
+other ragdoll bodies (4 — inter-bone and ragdoll-vs-ragdoll). Keep the
+CharacterBody3D that drives a ragdoll on its own layer (3) and disable its
+collider during reactions so the rig and controller body don't fight (see the
+CharacterBody3D integration notes in CLAUDE.md).
 
 ## Performance budget
 

--- a/docs/STEP_BY_STEP.md
+++ b/docs/STEP_BY_STEP.md
@@ -159,7 +159,7 @@ No spring resolver yet — just verify the physics rig works as a passive ragdol
   - One RigidBody3D per major bone (~16 bodies)
   - Connected by Generic6DOFJoint3D with angular limits
   - CapsuleShape3D for limbs, BoxShape3D for torso, SphereShape3D for head
-- Place on collision layer 4 (not layer 1 where CharacterBody3D lives)
+- Place on collision layer 4 (not the default layer 1, which is environment)
 - Make all RigidBody3Ds invisible (no mesh attached)
 - Write sync script: each _process, read RigidBody3D global transforms → write to
   the visible Skeleton3D via `set_bone_global_pose_override(bone_idx, transform, 1.0, true)`


### PR DESCRIPTION
## Summary

Resolves a project-wide collision-layer inconsistency for the 0.3.x gate. The foot-IK (`foot_ik_collision_mask`) and recovery (`ground_raycast_mask`) ground raycasts always defaulted to **layer 1**, and `INTEGRATION.md` documents layer 1 = environment — but `KickbackLayers.ENVIRONMENT_LAYER` was layer 2, the demo floors were on layer 2, and `foot_ik_demo`'s terrain was on layer 3. So **those ground raycasts silently missed the demo floors** (the rig still rested via body collision — mask 15 includes layer 2 — but foot-IK and recovery ground detection did nothing).

## Changes
- `KickbackLayers.ENVIRONMENT_LAYER`: **2 → 1** (ripples to the partial-ragdoll mask built in `SkeletonDetector`).
- **All 8 demo floors → layer 1**; `foot_ik_demo`'s 7 terrain pieces **layer 3 → layer 1**.
- **shooting_range**: player moved to its own layer (**3**) so it's off the environment layer (ground rays can't hit the FPS body); player mask **2 → 1** to keep colliding with the relocated ground; thrown-ball mask **10 → 9** (ground bit now layer 1).
- Setup-report dialog, `GODOT_CONSTRAINTS.md`, and `STEP_BY_STEP.md` updated to the layer-1-environment scheme (`INTEGRATION.md` already documented it; README has no layer table).

Active ragdoll bodies keep `collision_layer` 4 / `collision_mask` 15 (15 includes layer 1, so landing on the ground is unchanged).

## Net effect
Foot IK and recovery raycasts now actually hit the ground in **every** demo, not just where the layers happened to line up.

## Validation
- Headless import: clean
- GUT: **112/112** (this branch is off `main`; the +1 foot-IK test rides PR #80)
- Scene-smoke (`--quit-after 150`): clean (exit 0, 0 errors) on **all 8 demos**

## Visual sign-off
Wants an in-editor pass before merge: confirm feet now plant on the ground in the standard demos (e.g. `demo`, `euphoria_showcase`) and on the varied terrain in `foot_ik_demo`, and that `shooting_range` still walks/shoots and the thrown ball still knocks targets and rests on the floor.

## Merge note
Touches `CHANGELOG.md` like the other gate PRs — expect a trivial conflict (keep all bullets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)