### PR TITLE
refactor: extract demo wiring into demo_helpers.gd + add get_active_controller facade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@
   skeleton/modifier subsystem unchanged; the modifier's per-frame roll-back is what preserves
   the spring's clean `get_bone_pose()` read target). The migration itself shipped — see
   *Changed* below. Cross-linked from `GODOT_CONSTRAINTS.md` and `ROADMAP.md`.
+- **`KickbackCharacter.get_active_controller()`** — facade accessor returning the sibling
+  `ActiveRagdollController` (or null). Makes the README's `active_controller.*` advanced-query
+  pattern (balance / fatigue / pain / hit-streak / per-bone injuries) first-class, instead of
+  requiring callers to reach for the sibling node themselves.
 
 ### Fixed
 - **Multi-rig safety** — balance-driven stagger/ragdoll no longer silently disables on
@@ -139,6 +143,13 @@
   tool's node type changed (`Node` → `SkeletonModifier3D`). Validated headlessly (89 GUT tests
   incl. a signal-time multi-bone sync assertion that exercises the write ordering + clean
   scene-smoke on all 8 demos); mesh-tracking polish verified in-editor.
+- **Demo wiring deduplicated into `demo/demo_helpers.gd`** — the active-rig assembly,
+  skeleton / AnimationPlayer lookup, orbit-camera math, and debug-HUD setup that all 8 demo
+  scripts hand-duplicated are now shared static helpers (`build_active_rig`,
+  `find_skeleton_owner` / `find_descendant_of_type`, `orbit_camera`, `add_debug_hud`) — about
+  490 fewer lines across the demos. It is demo-only (not shipped with the plugin) and mirrors
+  the demos' wiring, deliberately distinct from `test/helpers/rig_harness.gd`. `signal_showcase`
+  and `euphoria_showcase` also adopt the new `get_active_controller()` facade.
 
 ### Removed
 - Dead passive-tracking path in `SpringResolver` (springs are always active) and its 5

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Or use the preset `.tres` files in `addons/kickback/presets/`.
 - **Persistent ragdoll (death):** `kickback_character.set_persistent(true)` — revive with `set_persistent(false)`
 - **Protected bones:** set `ragdoll_tuning.protected_bones` to keep legs (or any bones) animated during hits
 - **Query state:** `is_ragdolled()`, `is_staggering()`, `get_active_state_name()`
+- **Advanced control:** `var active_controller = kickback_character.get_active_controller()` — the `ActiveRagdollController` (or `null`), for the queries below
 - **Query balance:** `active_controller.get_balance_ratio()` — 0.0 = balanced, 1.0+ = off-balance
 - **Query fatigue:** `active_controller.get_fatigue()` — 0.0 = fresh, 1.0 = exhausted
 - **Reset fatigue:** `active_controller.reset_fatigue()` — on healing or respawn

--- a/addons/kickback/kickback_character.gd
+++ b/addons/kickback/kickback_character.gd
@@ -230,6 +230,14 @@ func get_character_root() -> Node3D:
 	return _character_root
 
 
+## Returns the sibling [ActiveRagdollController], or null if none is present.
+## Use this for the advanced queries/controls not surfaced directly on the facade
+## (balance ratio, fatigue, pain, hit streak, per-bone injuries). The facade
+## covers the common cases (trigger/state/hit routing); this is the escape hatch.
+func get_active_controller() -> ActiveRagdollController:
+	return _active_controller
+
+
 ## Recursively finds all KickbackCharacter nodes under [param root].
 static func find_all(root: Node) -> Array[KickbackCharacter]:
 	var result: Array[KickbackCharacter] = []

--- a/demo/animated_npc.gd
+++ b/demo/animated_npc.gd
@@ -3,6 +3,8 @@
 ## animations, gets up after ragdoll, walks injured, then resumes normal patrol.
 extends Node3D
 
+const DemoHelpers := preload("res://demo/demo_helpers.gd")
+
 const WALK_SPEED := 1.5
 const WAYPOINT_A := Vector3(-3, 0, 0)
 const WAYPOINT_B := Vector3(3, 0, 0)
@@ -55,7 +57,7 @@ func _ready() -> void:
 	_kickback = _setup_active(_char_root)
 
 	# Find AnimationPlayer and ActiveRagdollController
-	_anim = _find_child_of_type(_char_root, "AnimationPlayer")
+	_anim = DemoHelpers.find_descendant_of_type(_char_root, "AnimationPlayer")
 	for child in _char_root.get_children():
 		if child is ActiveRagdollController:
 			_active_ctrl = child
@@ -75,11 +77,7 @@ func _ready() -> void:
 		_anim.play.call_deferred("walk")
 
 	# Debug gizmos
-	var debug_hud := StrengthDebugHUD.new()
-	debug_hud.name = "StrengthDebugHUD"
-	debug_hud.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	debug_hud.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	add_child(debug_hud)
+	DemoHelpers.add_debug_hud(self)
 
 	_update_weapon_label()
 
@@ -183,15 +181,7 @@ func _update_camera() -> void:
 	if not _cam or not _char_root:
 		return
 	var pivot := _char_root.global_position + Vector3(0, 1.0, 0)
-	var yaw_rad := deg_to_rad(_cam_yaw)
-	var pitch_rad := deg_to_rad(_cam_pitch)
-	var offset := Vector3(
-		sin(yaw_rad) * cos(pitch_rad),
-		-sin(pitch_rad),
-		cos(yaw_rad) * cos(pitch_rad),
-	) * _cam_distance
-	_cam.global_position = pivot + offset
-	_cam.look_at(pivot)
+	DemoHelpers.orbit_camera(_cam, _cam_yaw, _cam_pitch, _cam_distance, pivot)
 
 
 # --- Directional animation picker ---
@@ -210,61 +200,7 @@ func _pick_directional(prefix: String, hit_dir: Vector3) -> String:
 # --- Kickback setup (same pattern as other demos) ---
 
 func _setup_active(char_root: Node3D) -> KickbackCharacter:
-	var ybot_name := ""
-	for child in char_root.get_children():
-		if _find_child_of_type(child, "Skeleton3D"):
-			ybot_name = child.name
-			break
-	if ybot_name.is_empty():
-		return null
-
-	var skel_path := NodePath("../%s/Skeleton3D" % ybot_name)
-	var root_path := NodePath("..")
-	var builder_path := NodePath("../PhysicsRigBuilder")
-	var spring_path := NodePath("../SpringResolver")
-
-	var rb := PhysicsRigBuilder.new()
-	rb.name = "PhysicsRigBuilder"
-	rb.skeleton_path = skel_path
-	var rs := PhysicsRigSync.new()
-	rs.name = "PhysicsRigSync"
-	rs.skeleton_path = skel_path
-	rs.rig_builder_path = builder_path
-	var sp := SpringResolver.new()
-	sp.name = "SpringResolver"
-	sp.skeleton_path = skel_path
-	sp.rig_builder_path = builder_path
-	var ac := ActiveRagdollController.new()
-	ac.name = "ActiveRagdollController"
-	ac.spring_resolver_path = spring_path
-	ac.rig_builder_path = builder_path
-	ac.character_root_path = root_path
-
-	var tuning := RagdollTuning.create_default()
-
-	var kc := KickbackCharacter.new()
-	kc.name = "KickbackCharacter"
-	kc.skeleton_path = skel_path
-	kc.character_root_path = root_path
-	kc.ragdoll_profile = RagdollProfile.create_mixamo_default()
-	kc.ragdoll_tuning = tuning
-
-	char_root.add_child(rb)
-	char_root.add_child(rs)
-	char_root.add_child(sp)
-	char_root.add_child(ac)
-	char_root.add_child(kc)
-	return kc
-
-
-func _find_child_of_type(node: Node, type_name: String) -> Node:
-	for child in node.get_children():
-		if child.get_class() == type_name:
-			return child
-		var found := _find_child_of_type(child, type_name)
-		if found:
-			return found
-	return null
+	return DemoHelpers.build_active_rig(char_root)
 
 
 func _make_profile(pname: StringName, impulse: float, transfer: float, upward: float,

--- a/demo/demo.gd
+++ b/demo/demo.gd
@@ -1,5 +1,7 @@
 extends Node3D
 
+const DemoHelpers := preload("res://demo/demo_helpers.gd")
+
 var _profiles: Array[ImpactProfile] = []
 var _weapon_names := PackedStringArray(["Bullet", "Melee", "Arrow", "Shotgun", "Explosion"])
 var _weapon_idx: int = 0
@@ -38,17 +40,13 @@ func _ready() -> void:
 	_setup_godot_ragdoll($PartialChar)
 
 	# Debug gizmos — self-contained, finds all characters
-	var debug_hud := StrengthDebugHUD.new()
-	debug_hud.name = "StrengthDebugHUD"
-	debug_hud.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	debug_hud.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	add_child(debug_hud)
+	DemoHelpers.add_debug_hud(self)
 
 	_update_weapon_label()
 
 
 func _setup_active(char_root: Node3D) -> KickbackCharacter:
-	var ybot_name := _get_ybot_name(char_root)
+	var ybot_name := DemoHelpers.find_skeleton_owner(char_root, "Demo")
 	if ybot_name.is_empty():
 		return null
 
@@ -58,44 +56,7 @@ func _setup_active(char_root: Node3D) -> KickbackCharacter:
 	if baked_sim:
 		baked_sim.queue_free()
 
-	var skel_path := NodePath("../%s/Skeleton3D" % ybot_name)
-	var root_path := NodePath("..")
-	var builder_path := NodePath("../PhysicsRigBuilder")
-	var spring_path := NodePath("../SpringResolver")
-
-	var rig_builder := PhysicsRigBuilder.new()
-	rig_builder.name = "PhysicsRigBuilder"
-	rig_builder.skeleton_path = skel_path
-
-	var rig_sync := PhysicsRigSync.new()
-	rig_sync.name = "PhysicsRigSync"
-	rig_sync.skeleton_path = skel_path
-	rig_sync.rig_builder_path = builder_path
-
-	var spring := SpringResolver.new()
-	spring.name = "SpringResolver"
-	spring.skeleton_path = skel_path
-	spring.rig_builder_path = builder_path
-
-	var active_ctrl := ActiveRagdollController.new()
-	active_ctrl.name = "ActiveRagdollController"
-	active_ctrl.spring_resolver_path = spring_path
-	active_ctrl.rig_builder_path = builder_path
-	active_ctrl.character_root_path = root_path
-
-	var kc := KickbackCharacter.new()
-	kc.name = "KickbackCharacter"
-	kc.skeleton_path = skel_path
-	kc.character_root_path = root_path
-	kc.ragdoll_profile = RagdollProfile.create_mixamo_default()
-	kc.ragdoll_tuning = RagdollTuning.create_default()
-
-	char_root.add_child(rig_builder)
-	char_root.add_child(rig_sync)
-	char_root.add_child(spring)
-	char_root.add_child(active_ctrl)
-	char_root.add_child(kc)
-	return kc
+	return DemoHelpers.build_active_rig(char_root, ybot_name)
 
 
 # The "what Godot offers" half: a bare PhysicalBoneSimulator3D ragdoll driven by
@@ -103,7 +64,7 @@ func _setup_active(char_root: Node3D) -> KickbackCharacter:
 # Kickback is the active spring ragdoll on the left; this side is the engine's
 # built-in tool, for contrast.
 func _setup_godot_ragdoll(char_root: Node3D) -> void:
-	var ybot_name := _get_ybot_name(char_root)
+	var ybot_name := DemoHelpers.find_skeleton_owner(char_root, "Demo")
 	if ybot_name.is_empty():
 		return
 
@@ -120,24 +81,6 @@ func _setup_godot_ragdoll(char_root: Node3D) -> void:
 	_godot_ctrl.simulator_path = sim_path
 	_godot_ctrl.skeleton_path = skel_path
 	char_root.add_child(_godot_ctrl)
-
-
-func _get_ybot_name(char_root: Node3D) -> String:
-	for child in char_root.get_children():
-		if _find_child_of_type(child, "Skeleton3D"):
-			return child.name
-	push_error("Demo: No Skeleton3D found in %s" % char_root.name)
-	return ""
-
-
-func _find_child_of_type(node: Node, type_name: String) -> Node:
-	for child in node.get_children():
-		if child.get_class() == type_name:
-			return child
-		var found := _find_child_of_type(child, type_name)
-		if found:
-			return found
-	return null
 
 
 func _unhandled_input(event: InputEvent) -> void:
@@ -186,18 +129,7 @@ func _physics_process(delta: float) -> void:
 		return
 
 	# Camera orbits the midpoint between both characters
-	var pivot := Vector3(0, 1.0, 0)
-	var yaw_rad := deg_to_rad(_cam_yaw)
-	var pitch_rad := deg_to_rad(_cam_pitch)
-
-	var offset := Vector3(
-		sin(yaw_rad) * cos(pitch_rad),
-		-sin(pitch_rad),
-		cos(yaw_rad) * cos(pitch_rad),
-	) * _cam_distance
-
-	_cam.global_position = pivot + offset
-	_cam.look_at(pivot)
+	DemoHelpers.orbit_camera(_cam, _cam_yaw, _cam_pitch, _cam_distance)
 
 
 func _set_weapon(idx: int) -> void:

--- a/demo/demo_helpers.gd
+++ b/demo/demo_helpers.gd
@@ -1,0 +1,115 @@
+## Shared wiring helpers for the Kickback DEMO scenes. NOT part of the plugin —
+## it lives under demo/ and is preloaded by the demo scripts to collapse the
+## active-rig assembly, skeleton lookup, orbit-camera math, and debug-HUD setup
+## that every demo otherwise hand-duplicates.
+##
+## This intentionally mirrors the DEMOS' wiring: it sets NodePaths and relies on
+## each controller's defaults (it does NOT call .configure() up front, and does
+## NOT set the controller's rig_sync_path). That differs from
+## test/helpers/rig_harness.gd, which configures every node explicitly for the
+## headless tests — keep the two separate.
+##
+## Usage:
+##   const DemoHelpers := preload("res://demo/demo_helpers.gd")
+##   var kc := DemoHelpers.build_active_rig(char_root)
+extends RefCounted
+
+
+## Builds the full Kickback active-ragdoll node graph (PhysicsRigBuilder +
+## PhysicsRigSync + SpringResolver + ActiveRagdollController + KickbackCharacter)
+## as children of [param char_root] and returns the KickbackCharacter (or null if
+## no Skeleton3D is found). [param skeleton_owner] is the char_root child that owns
+## the Skeleton3D (auto-detected when ""). [param tuning] / [param profile] override
+## the Mixamo/default config.
+static func build_active_rig(char_root: Node3D, skeleton_owner: String = "",
+		tuning: RagdollTuning = null, profile: RagdollProfile = null) -> KickbackCharacter:
+	var owner_name := skeleton_owner if skeleton_owner != "" else find_skeleton_owner(char_root)
+	if owner_name == "":
+		return null
+
+	var skel_path := NodePath("../%s/Skeleton3D" % owner_name)
+	var builder_path := NodePath("../PhysicsRigBuilder")
+	var spring_path := NodePath("../SpringResolver")
+	var root_path := NodePath("..")
+
+	var rig_builder := PhysicsRigBuilder.new()
+	rig_builder.name = "PhysicsRigBuilder"
+	rig_builder.skeleton_path = skel_path
+
+	var rig_sync := PhysicsRigSync.new()
+	rig_sync.name = "PhysicsRigSync"
+	rig_sync.skeleton_path = skel_path
+	rig_sync.rig_builder_path = builder_path
+
+	var spring := SpringResolver.new()
+	spring.name = "SpringResolver"
+	spring.skeleton_path = skel_path
+	spring.rig_builder_path = builder_path
+
+	var active_ctrl := ActiveRagdollController.new()
+	active_ctrl.name = "ActiveRagdollController"
+	active_ctrl.spring_resolver_path = spring_path
+	active_ctrl.rig_builder_path = builder_path
+	active_ctrl.character_root_path = root_path
+
+	var kc := KickbackCharacter.new()
+	kc.name = "KickbackCharacter"
+	kc.skeleton_path = skel_path
+	kc.character_root_path = root_path
+	kc.ragdoll_profile = profile if profile else RagdollProfile.create_mixamo_default()
+	kc.ragdoll_tuning = tuning if tuning else RagdollTuning.create_default()
+
+	char_root.add_child(rig_builder)
+	char_root.add_child(rig_sync)
+	char_root.add_child(spring)
+	char_root.add_child(active_ctrl)
+	char_root.add_child(kc)
+	return kc
+
+
+## Returns the name of the [param char_root] child whose subtree contains a
+## Skeleton3D, or "" (with an error) when none is present.
+static func find_skeleton_owner(char_root: Node3D, error_prefix: String = "DemoHelpers") -> String:
+	for child in char_root.get_children():
+		if find_descendant_of_type(child, "Skeleton3D"):
+			return child.name
+	push_error("%s: No Skeleton3D found in %s" % [error_prefix, char_root.name])
+	return ""
+
+
+## Depth-first search of [param node]'s descendants for the first node whose class
+## is [param type_name] (e.g. "Skeleton3D", "AnimationPlayer"). Returns null if none.
+static func find_descendant_of_type(node: Node, type_name: String) -> Node:
+	for child in node.get_children():
+		if child.get_class() == type_name:
+			return child
+		var found := find_descendant_of_type(child, type_name)
+		if found:
+			return found
+	return null
+
+
+## Positions an orbit camera at the given yaw/pitch (degrees) and distance around
+## [param pivot], then looks at the pivot. The spherical-coords math shared by
+## every orbiting demo; input capture and clamps stay per-demo.
+static func orbit_camera(cam: Camera3D, yaw_deg: float, pitch_deg: float,
+		distance: float, pivot: Vector3 = Vector3(0.0, 1.0, 0.0)) -> void:
+	var yaw_rad := deg_to_rad(yaw_deg)
+	var pitch_rad := deg_to_rad(pitch_deg)
+	var offset := Vector3(
+		sin(yaw_rad) * cos(pitch_rad),
+		-sin(pitch_rad),
+		cos(yaw_rad) * cos(pitch_rad),
+	) * distance
+	cam.global_position = pivot + offset
+	cam.look_at(pivot)
+
+
+## Instantiates the F3 StrengthDebugHUD overlay and adds it under [param parent].
+static func add_debug_hud(parent: Node) -> StrengthDebugHUD:
+	var hud := StrengthDebugHUD.new()
+	hud.name = "StrengthDebugHUD"
+	hud.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	hud.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	parent.add_child(hud)
+	return hud

--- a/demo/demo_helpers.gd.uid
+++ b/demo/demo_helpers.gd.uid
@@ -1,0 +1,1 @@
+uid://cyy5qr2iyak1r

--- a/demo/euphoria_showcase.gd
+++ b/demo/euphoria_showcase.gd
@@ -4,6 +4,8 @@
 ## Right: Injuries (regional impairment, micro reactions, threat anticipation)
 extends Node3D
 
+const DemoHelpers := preload("res://demo/demo_helpers.gd")
+
 const WALK_SPEED := 1.8
 
 var _profiles: Array[ImpactProfile] = []
@@ -70,16 +72,12 @@ func _ready() -> void:
 		moving_ctrl.stagger_finished.connect(_on_mover_stagger_finished)
 
 	# Start walk animation
-	_moving_anim = _find_child_of_type(_char_roots[1], "AnimationPlayer")
+	_moving_anim = DemoHelpers.find_descendant_of_type(_char_roots[1], "AnimationPlayer")
 	if _moving_anim:
 		_moving_anim.call_deferred("play", "walk")
 
 	# Debug gizmos
-	var debug_hud := StrengthDebugHUD.new()
-	debug_hud.name = "StrengthDebugHUD"
-	debug_hud.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	debug_hud.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	add_child(debug_hud)
+	DemoHelpers.add_debug_hud(self)
 
 
 # --- Moving target signal handlers ---
@@ -104,62 +102,10 @@ func _on_mover_stagger_finished() -> void:
 # --- Setup ---
 
 func _setup_active(char_root: Node3D) -> KickbackCharacter:
-	var ybot_name := ""
-	for child in char_root.get_children():
-		if _find_child_of_type(child, "Skeleton3D"):
-			ybot_name = child.name
-			break
-	if ybot_name.is_empty():
-		return null
-
-	var skel_path := NodePath("../%s/Skeleton3D" % ybot_name)
-	var root_path := NodePath("..")
-	var builder_path := NodePath("../PhysicsRigBuilder")
-	var spring_path := NodePath("../SpringResolver")
-
-	var rb := PhysicsRigBuilder.new()
-	rb.name = "PhysicsRigBuilder"
-	rb.skeleton_path = skel_path
-	var rs := PhysicsRigSync.new()
-	rs.name = "PhysicsRigSync"
-	rs.skeleton_path = skel_path
-	rs.rig_builder_path = builder_path
-	var sp := SpringResolver.new()
-	sp.name = "SpringResolver"
-	sp.skeleton_path = skel_path
-	sp.rig_builder_path = builder_path
-	var ac := ActiveRagdollController.new()
-	ac.name = "ActiveRagdollController"
-	ac.spring_resolver_path = spring_path
-	ac.rig_builder_path = builder_path
-	ac.character_root_path = root_path
-	_controllers.append(ac)
-
-	var tuning := RagdollTuning.create_default()
-
-	var kc := KickbackCharacter.new()
-	kc.name = "KickbackCharacter"
-	kc.skeleton_path = skel_path
-	kc.character_root_path = root_path
-	kc.ragdoll_profile = RagdollProfile.create_mixamo_default()
-	kc.ragdoll_tuning = tuning
-
-	char_root.add_child(rb)
-	char_root.add_child(rs)
-	char_root.add_child(sp)
-	char_root.add_child(ac)
-	char_root.add_child(kc)
+	var kc := DemoHelpers.build_active_rig(char_root)
+	if kc:
+		_controllers.append(kc.get_active_controller())
 	return kc
-
-
-func _find_child_of_type(node: Node, type_name: String) -> Node:
-	for child in node.get_children():
-		if child.get_class() == type_name:
-			return child
-		var found := _find_child_of_type(child, type_name)
-		if found:
-			return found
-	return null
 
 
 func _physics_process(delta: float) -> void:
@@ -184,16 +130,7 @@ func _physics_process(delta: float) -> void:
 func _update_camera() -> void:
 	if not _cam:
 		return
-	var pivot := Vector3(0, 1.0, 0)
-	var yaw_rad := deg_to_rad(_cam_yaw)
-	var pitch_rad := deg_to_rad(_cam_pitch)
-	var offset := Vector3(
-		sin(yaw_rad) * cos(pitch_rad),
-		-sin(pitch_rad),
-		cos(yaw_rad) * cos(pitch_rad),
-	) * _cam_distance
-	_cam.global_position = pivot + offset
-	_cam.look_at(pivot)
+	DemoHelpers.orbit_camera(_cam, _cam_yaw, _cam_pitch, _cam_distance)
 
 
 func _unhandled_input(event: InputEvent) -> void:

--- a/demo/foot_ik_demo.gd
+++ b/demo/foot_ik_demo.gd
@@ -4,6 +4,8 @@
 ## Right (Z=2.5): foot IK disabled — feet float through terrain.
 extends Node3D
 
+const DemoHelpers := preload("res://demo/demo_helpers.gd")
+
 const WALK_SPEED := 1.5
 const WAYPOINT_A := Vector3(-6, 0, 0)
 const WAYPOINT_B := Vector3(6, 0, 0)
@@ -45,11 +47,7 @@ func _ready() -> void:
 	_setup_hud()
 	_add_3d_labels()
 
-	var dh := StrengthDebugHUD.new()
-	dh.name = "StrengthDebugHUD"
-	dh.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	dh.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	add_child(dh)
+	DemoHelpers.add_debug_hud(self)
 
 
 # =============================================================================
@@ -60,59 +58,21 @@ func _init_npc(char_root: Node3D, label: String, ik_enabled: bool) -> Dictionary
 	if not char_root:
 		return {}
 
-	var ybot_name := _get_ybot_name(char_root)
-	if ybot_name.is_empty():
-		return {}
-
-	var skel_path := NodePath("../%s/Skeleton3D" % ybot_name)
-	var root_path := NodePath("..")
-	var builder_path := NodePath("../PhysicsRigBuilder")
-	var spring_path := NodePath("../SpringResolver")
-
-	var rb := PhysicsRigBuilder.new()
-	rb.name = "PhysicsRigBuilder"
-	rb.skeleton_path = skel_path
-
-	var rs := PhysicsRigSync.new()
-	rs.name = "PhysicsRigSync"
-	rs.skeleton_path = skel_path
-	rs.rig_builder_path = builder_path
-
-	var sp := SpringResolver.new()
-	sp.name = "SpringResolver"
-	sp.skeleton_path = skel_path
-	sp.rig_builder_path = builder_path
-
-	var ac := ActiveRagdollController.new()
-	ac.name = "ActiveRagdollController"
-	ac.spring_resolver_path = spring_path
-	ac.rig_builder_path = builder_path
-	ac.character_root_path = root_path
-
 	var tuning := RagdollTuning.create_default()
 	tuning.foot_ik_enabled = ik_enabled
-
-	var kc := KickbackCharacter.new()
-	kc.name = "KickbackCharacter"
-	kc.skeleton_path = skel_path
-	kc.character_root_path = root_path
-	kc.ragdoll_profile = RagdollProfile.create_mixamo_default()
-	kc.ragdoll_tuning = tuning
-
-	char_root.add_child(rb)
-	char_root.add_child(rs)
-	char_root.add_child(sp)
-	char_root.add_child(ac)
-	char_root.add_child(kc)
+	var kc := DemoHelpers.build_active_rig(char_root, "", tuning)
+	if not kc:
+		return {}
+	var ac := kc.get_active_controller()
 
 	# Find anim player + skeleton
 	var anim: AnimationPlayer
 	var skeleton: Skeleton3D
 	for child in char_root.get_children():
-		var a := _find_child_of_type(child, "AnimationPlayer") as AnimationPlayer
+		var a := DemoHelpers.find_descendant_of_type(child, "AnimationPlayer") as AnimationPlayer
 		if a:
 			anim = a
-		var s := _find_child_of_type(child, "Skeleton3D") as Skeleton3D
+		var s := DemoHelpers.find_descendant_of_type(child, "Skeleton3D") as Skeleton3D
 		if s:
 			skeleton = s
 
@@ -199,11 +159,7 @@ func _update_camera() -> void:
 	if not _cam or _npc_ik.is_empty():
 		return
 	var pivot: Vector3 = _npc_ik.char_root.global_position + Vector3(0, 1.0, 1.25)
-	var yr := deg_to_rad(_cam_yaw)
-	var pr := deg_to_rad(_cam_pitch)
-	var off := Vector3(sin(yr) * cos(pr), -sin(pr), cos(yr) * cos(pr)) * _cam_distance
-	_cam.global_position = pivot + off
-	_cam.look_at(pivot)
+	DemoHelpers.orbit_camera(_cam, _cam_yaw, _cam_pitch, _cam_distance, pivot)
 
 
 # =============================================================================
@@ -299,23 +255,4 @@ func _add_3d_labels() -> void:
 	label_no_ik.position = Vector3(0, 2.5, 2.5)
 
 
-# =============================================================================
-# UTILITIES
-# =============================================================================
-
-func _get_ybot_name(char_root: Node3D) -> String:
-	for child in char_root.get_children():
-		if _find_child_of_type(child, "Skeleton3D"):
-			return child.name
-	push_error("FootIKDemo: No Skeleton3D found in %s" % char_root.name)
-	return ""
-
-
-func _find_child_of_type(node: Node, type_name: String) -> Node:
-	for child in node.get_children():
-		if child.get_class() == type_name:
-			return child
-		var found := _find_child_of_type(child, type_name)
-		if found:
-			return found
-	return null
+# (skeleton/anim lookup now lives in demo_helpers.gd)

--- a/demo/shooting_range.gd
+++ b/demo/shooting_range.gd
@@ -3,6 +3,8 @@
 ## physics ball (alt-fire). Characters stagger, ragdoll, and recover from hits.
 extends CharacterBody3D
 
+const DemoHelpers := preload("res://demo/demo_helpers.gd")
+
 const SPEED := 5.0
 const MOUSE_SENSITIVITY := 0.002
 
@@ -45,11 +47,7 @@ func _ready() -> void:
 		_setup_active(char_root)
 
 	# Debug gizmos
-	var debug_hud := StrengthDebugHUD.new()
-	debug_hud.name = "StrengthDebugHUD"
-	debug_hud.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	debug_hud.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	get_node("../HUD").add_child(debug_hud)
+	DemoHelpers.add_debug_hud(get_node("../HUD"))
 
 	_capture_mouse()
 	_update_weapon_label()
@@ -57,67 +55,7 @@ func _ready() -> void:
 
 
 func _setup_active(char_root: Node3D) -> void:
-	var ybot_name := _get_ybot_name(char_root)
-	if ybot_name.is_empty():
-		return
-
-	var skel_path := NodePath("../%s/Skeleton3D" % ybot_name)
-	var root_path := NodePath("..")
-	var builder_path := NodePath("../PhysicsRigBuilder")
-	var spring_path := NodePath("../SpringResolver")
-
-	var rig_builder := PhysicsRigBuilder.new()
-	rig_builder.name = "PhysicsRigBuilder"
-	rig_builder.skeleton_path = skel_path
-
-	var rig_sync := PhysicsRigSync.new()
-	rig_sync.name = "PhysicsRigSync"
-	rig_sync.skeleton_path = skel_path
-	rig_sync.rig_builder_path = builder_path
-
-	var spring := SpringResolver.new()
-	spring.name = "SpringResolver"
-	spring.skeleton_path = skel_path
-	spring.rig_builder_path = builder_path
-
-	var active_ctrl := ActiveRagdollController.new()
-	active_ctrl.name = "ActiveRagdollController"
-	active_ctrl.spring_resolver_path = spring_path
-	active_ctrl.rig_builder_path = builder_path
-	active_ctrl.character_root_path = root_path
-
-	var tuning := RagdollTuning.create_default()
-
-	var kc := KickbackCharacter.new()
-	kc.name = "KickbackCharacter"
-	kc.skeleton_path = skel_path
-	kc.character_root_path = root_path
-	kc.ragdoll_profile = RagdollProfile.create_mixamo_default()
-	kc.ragdoll_tuning = tuning
-
-	char_root.add_child(rig_builder)
-	char_root.add_child(rig_sync)
-	char_root.add_child(spring)
-	char_root.add_child(active_ctrl)
-	char_root.add_child(kc)
-
-
-func _get_ybot_name(char_root: Node3D) -> String:
-	for child in char_root.get_children():
-		if _find_child_of_type(child, "Skeleton3D"):
-			return child.name
-	push_error("ShootingRange: No Skeleton3D found in %s" % char_root.name)
-	return ""
-
-
-func _find_child_of_type(node: Node, type_name: String) -> Node:
-	for child in node.get_children():
-		if child.get_class() == type_name:
-			return child
-		var found := _find_child_of_type(child, type_name)
-		if found:
-			return found
-	return null
+	DemoHelpers.build_active_rig(char_root)
 
 
 func _capture_mouse() -> void:

--- a/demo/signal_showcase.gd
+++ b/demo/signal_showcase.gd
@@ -1,5 +1,7 @@
 extends Node3D
 
+const DemoHelpers := preload("res://demo/demo_helpers.gd")
+
 var _profiles: Array[ImpactProfile] = []
 var _weapon_names := PackedStringArray(["Bullet", "Melee", "Arrow", "Shotgun", "Explosion"])
 var _weapon_idx: int = 0
@@ -42,12 +44,7 @@ func _ready() -> void:
 
 	# Connect all signals for visualization
 	if _kickback:
-		var active_ctrl: ActiveRagdollController = null
-		for sibling in _char_root.get_children():
-			if sibling is ActiveRagdollController:
-				active_ctrl = sibling
-				break
-
+		var active_ctrl := _kickback.get_active_controller()
 		if active_ctrl:
 			active_ctrl.hit_absorbed.connect(_on_hit_absorbed)
 			active_ctrl.stagger_started.connect(_on_stagger_started)
@@ -64,71 +61,13 @@ func _ready() -> void:
 			active_ctrl.threat_anticipated.connect(_on_threat_anticipated)
 
 	# Debug gizmos
-	var debug_hud := StrengthDebugHUD.new()
-	debug_hud.name = "StrengthDebugHUD"
-	debug_hud.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	debug_hud.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	add_child(debug_hud)
+	DemoHelpers.add_debug_hud(self)
 
 	_update_weapon_label()
 
 
 func _setup_active(char_root: Node3D) -> KickbackCharacter:
-	var ybot_name := ""
-	for child in char_root.get_children():
-		if _find_child_of_type(child, "Skeleton3D"):
-			ybot_name = child.name
-			break
-	if ybot_name.is_empty():
-		return null
-
-	var skel_path := NodePath("../%s/Skeleton3D" % ybot_name)
-	var root_path := NodePath("..")
-	var builder_path := NodePath("../PhysicsRigBuilder")
-	var spring_path := NodePath("../SpringResolver")
-
-	var rb := PhysicsRigBuilder.new()
-	rb.name = "PhysicsRigBuilder"
-	rb.skeleton_path = skel_path
-	var rs := PhysicsRigSync.new()
-	rs.name = "PhysicsRigSync"
-	rs.skeleton_path = skel_path
-	rs.rig_builder_path = builder_path
-	var sp := SpringResolver.new()
-	sp.name = "SpringResolver"
-	sp.skeleton_path = skel_path
-	sp.rig_builder_path = builder_path
-	var ac := ActiveRagdollController.new()
-	ac.name = "ActiveRagdollController"
-	ac.spring_resolver_path = spring_path
-	ac.rig_builder_path = builder_path
-	ac.character_root_path = root_path
-
-	var tuning := RagdollTuning.create_default()
-
-	var kc := KickbackCharacter.new()
-	kc.name = "KickbackCharacter"
-	kc.skeleton_path = skel_path
-	kc.character_root_path = root_path
-	kc.ragdoll_profile = RagdollProfile.create_mixamo_default()
-	kc.ragdoll_tuning = tuning
-
-	char_root.add_child(rb)
-	char_root.add_child(rs)
-	char_root.add_child(sp)
-	char_root.add_child(ac)
-	char_root.add_child(kc)
-	return kc
-
-
-func _find_child_of_type(node: Node, type_name: String) -> Node:
-	for child in node.get_children():
-		if child.get_class() == type_name:
-			return child
-		var found := _find_child_of_type(child, type_name)
-		if found:
-			return found
-	return null
+	return DemoHelpers.build_active_rig(char_root)
 
 
 # --- Signal handlers ---
@@ -255,15 +194,7 @@ func _physics_process(_delta: float) -> void:
 	if not _cam:
 		return
 	var pivot := _char_root.global_position + Vector3(0, 1.0, 0) if _char_root else Vector3(0, 1, 0)
-	var yaw_rad := deg_to_rad(_cam_yaw)
-	var pitch_rad := deg_to_rad(_cam_pitch)
-	var offset := Vector3(
-		sin(yaw_rad) * cos(pitch_rad),
-		-sin(pitch_rad),
-		cos(yaw_rad) * cos(pitch_rad),
-	) * _cam_distance
-	_cam.global_position = pivot + offset
-	_cam.look_at(pivot)
+	DemoHelpers.orbit_camera(_cam, _cam_yaw, _cam_pitch, _cam_distance, pivot)
 
 
 func _set_weapon(idx: int) -> void:

--- a/demo/stress_test.gd
+++ b/demo/stress_test.gd
@@ -1,5 +1,7 @@
 extends Node3D
 
+const DemoHelpers := preload("res://demo/demo_helpers.gd")
+
 const GRID_COLS := 5
 const GRID_ROWS := 4
 const SPACING := 2.5
@@ -62,51 +64,11 @@ func _ready() -> void:
 	_build_budget_slider()
 
 	# Debug gizmos
-	var debug_hud := StrengthDebugHUD.new()
-	debug_hud.name = "StrengthDebugHUD"
-	debug_hud.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	debug_hud.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	add_child(debug_hud)
+	DemoHelpers.add_debug_hud(self)
 
 
 func _setup_active(char_root: Node3D, ybot_name: String) -> KickbackCharacter:
-	var skel_path := NodePath("../%s/Skeleton3D" % ybot_name)
-	var root_path := NodePath("..")
-	var builder_path := NodePath("../PhysicsRigBuilder")
-	var spring_path := NodePath("../SpringResolver")
-
-	var rb := PhysicsRigBuilder.new()
-	rb.name = "PhysicsRigBuilder"
-	rb.skeleton_path = skel_path
-	var rs := PhysicsRigSync.new()
-	rs.name = "PhysicsRigSync"
-	rs.skeleton_path = skel_path
-	rs.rig_builder_path = builder_path
-	var sp := SpringResolver.new()
-	sp.name = "SpringResolver"
-	sp.skeleton_path = skel_path
-	sp.rig_builder_path = builder_path
-	var ac := ActiveRagdollController.new()
-	ac.name = "ActiveRagdollController"
-	ac.spring_resolver_path = spring_path
-	ac.rig_builder_path = builder_path
-	ac.character_root_path = root_path
-
-	var tuning := RagdollTuning.create_default()
-
-	var kc := KickbackCharacter.new()
-	kc.name = "KickbackCharacter"
-	kc.skeleton_path = skel_path
-	kc.character_root_path = root_path
-	kc.ragdoll_profile = RagdollProfile.create_mixamo_default()
-	kc.ragdoll_tuning = tuning
-
-	char_root.add_child(rb)
-	char_root.add_child(rs)
-	char_root.add_child(sp)
-	char_root.add_child(ac)
-	char_root.add_child(kc)
-	return kc
+	return DemoHelpers.build_active_rig(char_root, ybot_name)
 
 
 func _build_budget_slider() -> void:
@@ -176,16 +138,7 @@ func _unhandled_input(event: InputEvent) -> void:
 func _physics_process(_delta: float) -> void:
 	if not _cam:
 		return
-	var pivot := Vector3(0, 1.0, 0)
-	var yaw_rad := deg_to_rad(_cam_yaw)
-	var pitch_rad := deg_to_rad(_cam_pitch)
-	var offset := Vector3(
-		sin(yaw_rad) * cos(pitch_rad),
-		-sin(pitch_rad),
-		cos(yaw_rad) * cos(pitch_rad),
-	) * _cam_distance
-	_cam.global_position = pivot + offset
-	_cam.look_at(pivot)
+	DemoHelpers.orbit_camera(_cam, _cam_yaw, _cam_pitch, _cam_distance)
 
 	# Update FPS
 	if _fps_label:

--- a/demo/tuning_playground.gd
+++ b/demo/tuning_playground.gd
@@ -4,6 +4,8 @@
 ## with the same hit so you can compare how each tuning reacts.
 extends Node3D
 
+const DemoHelpers := preload("res://demo/demo_helpers.gd")
+
 var _profile: ImpactProfile           # shared test-hit profile (IMPACT sliders edit this)
 var _custom_tuning: RagdollTuning     # Custom character's body tuning (all other sliders)
 var _custom_kickback: KickbackCharacter
@@ -40,11 +42,7 @@ func _ready() -> void:
 	_custom_kickback = _setup_character($Characters/Custom, _custom_tuning)
 
 	# Debug gizmos
-	var debug_hud := StrengthDebugHUD.new()
-	debug_hud.name = "StrengthDebugHUD"
-	debug_hud.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	debug_hud.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	add_child(debug_hud)
+	DemoHelpers.add_debug_hud(self)
 
 	_build_slider_panel()
 
@@ -95,63 +93,10 @@ func _make_protected_tuning() -> RagdollTuning:
 
 
 func _setup_character(char_root: Node3D, tuning: RagdollTuning) -> KickbackCharacter:
-	var ybot_name := ""
-	for child in char_root.get_children():
-		if _find_child_of_type(child, "Skeleton3D"):
-			ybot_name = child.name
-			break
-	if ybot_name.is_empty():
-		return null
-
-	var skel_path := NodePath("../%s/Skeleton3D" % ybot_name)
-	var root_path := NodePath("..")
-	var builder_path := NodePath("../PhysicsRigBuilder")
-	var spring_path := NodePath("../SpringResolver")
-
-	var rb := PhysicsRigBuilder.new()
-	rb.name = "PhysicsRigBuilder"
-	rb.skeleton_path = skel_path
-
-	var rs := PhysicsRigSync.new()
-	rs.name = "PhysicsRigSync"
-	rs.skeleton_path = skel_path
-	rs.rig_builder_path = builder_path
-
-	var sp := SpringResolver.new()
-	sp.name = "SpringResolver"
-	sp.skeleton_path = skel_path
-	sp.rig_builder_path = builder_path
-
-	var ac := ActiveRagdollController.new()
-	ac.name = "ActiveRagdollController"
-	ac.spring_resolver_path = spring_path
-	ac.rig_builder_path = builder_path
-	ac.character_root_path = root_path
-
-	var kc := KickbackCharacter.new()
-	kc.name = "KickbackCharacter"
-	kc.skeleton_path = skel_path
-	kc.character_root_path = root_path
-	kc.ragdoll_profile = RagdollProfile.create_mixamo_default()
-	kc.ragdoll_tuning = tuning
-
-	char_root.add_child(rb)
-	char_root.add_child(rs)
-	char_root.add_child(sp)
-	char_root.add_child(ac)
-	char_root.add_child(kc)
-	_kickbacks.append(kc)
+	var kc := DemoHelpers.build_active_rig(char_root, "", tuning)
+	if kc:
+		_kickbacks.append(kc)
 	return kc
-
-
-func _find_child_of_type(node: Node, type_name: String) -> Node:
-	for child in node.get_children():
-		if child.get_class() == type_name:
-			return child
-		var found := _find_child_of_type(child, type_name)
-		if found:
-			return found
-	return null
 
 
 # --- Slider panel (edits the Custom character) ---
@@ -363,13 +308,4 @@ func _unhandled_input(event: InputEvent) -> void:
 func _physics_process(_delta: float) -> void:
 	if not _cam:
 		return
-	var pivot := Vector3(0, 1.0, 0)
-	var yaw_rad := deg_to_rad(_cam_yaw)
-	var pitch_rad := deg_to_rad(_cam_pitch)
-	var offset := Vector3(
-		sin(yaw_rad) * cos(pitch_rad),
-		-sin(pitch_rad),
-		cos(yaw_rad) * cos(pitch_rad),
-	) * _cam_distance
-	_cam.global_position = pivot + offset
-	_cam.look_at(pivot)
+	DemoHelpers.orbit_camera(_cam, _cam_yaw, _cam_pitch, _cam_distance)


### PR DESCRIPTION
## Summary

Leanness pass over the 8 demo scripts (demos only — not part of the shipped plugin), plus a small facade addition. Final 0.3.x gate PR.

## New `demo/demo_helpers.gd`
Collects the wiring every demo hand-duplicated into shared static helpers:
- `build_active_rig()` — assemble the full active-ragdoll node graph (PhysicsRigBuilder + PhysicsRigSync + SpringResolver + ActiveRagdollController + KickbackCharacter)
- `find_skeleton_owner()` / `find_descendant_of_type()` — locate the `Skeleton3D` / `AnimationPlayer`
- `orbit_camera()` — the spherical-coords orbit math (pivot parameterized for world vs character-relative)
- `add_debug_hud()` — instantiate + add the F3 `StrengthDebugHUD` (parent parameterized)

All 8 demos now call these instead of repeating ~30 / 15 / 10 / 5-line blocks each — **~490 fewer lines across `demo/`** (554 deleted, 63 added).

The helper intentionally **mirrors the demos' wiring** (sets NodePaths, relies on controller defaults — no `.configure()`, no `rig_sync_path`), which is distinct from `test/helpers/rig_harness.gd` (that one configures every node explicitly for the headless tests). The two are kept separate per the analysis.

## Facade
`KickbackCharacter.get_active_controller()` returns the sibling `ActiveRagdollController` (or null), making the README's `active_controller.*` advanced-query pattern (balance / fatigue / pain / hit-streak / injuries) first-class. `signal_showcase` and `euphoria_showcase` adopt it to drop their own sibling-scan loops.

## Validation
- Headless import: clean
- GUT: **112/112** (facade is additive)
- Scene-smoke (`--quit-after 150`): clean (exit 0, 0 errors) on **all 8 demos**

This PR is tagged scene-smoke (no feel changes — pure wiring dedup), so it doesn't need an in-editor visual pass; the 8 clean scene-smokes cover load + runtime.

## Merge note
Touches `CHANGELOG.md` like the other gate PRs — expect a trivial conflict with PR #79/#80/#81 (keep all bullets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)