### PR TITLE
feat: stumble-step decision logic + tuning (0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@
 
 ## [Unreleased]
 
+### Added
+- **Stumble-step decision logic** (0.4.0 Self-Preservation) — `StumblePlanner`, the
+  pure, stateless decision core for procedural stumble recovery: given the balance
+  imbalance direction and foot positions it selects the trailing foot to step and
+  computes a balance-scaled, reach-clamped step target. Side-effect-free and
+  unit-tested without a live rig (`test/test_stumble_planner.gd`). New `RagdollTuning`
+  "Self-Preservation: Stumble Steps" group (`stumble_enabled`, `stumble_step_threshold`,
+  `stumble_step_length`, `stumble_step_reach_max`, `stumble_step_duration`,
+  `stumble_step_cooldown`, `stumble_max_steps`). Decision + tuning only — execution
+  (driving the foot through the foot IK solver) and controller wiring land in the next PR.
+
 ### Fixed
 - **Foot-IK idle leg buzz** — the two-bone IK solver built each leg segment's
   orientation target from scratch with an assumed local-axis convention

--- a/addons/kickback/resources/ragdoll_tuning.gd
+++ b/addons/kickback/resources/ragdoll_tuning.gd
@@ -358,6 +358,34 @@ extends Resource
 @export_range(0.1, 1.0) var foot_ik_stagger_leg_strength: float = 0.4
 
 
+# ── Self-Preservation: Stumble Steps ────────────────────────────────────────
+
+@export_group("Self-Preservation: Stumble Steps")
+## Enable procedural stumble stepping: during STAGGER, the trailing foot swings in
+## the fall direction to catch a loss of balance before it becomes a fall.
+## Requires foot IK (the step is executed through the foot IK solver). 0.4.0.
+@export var stumble_enabled: bool = true
+## Balance ratio above which a stumble step is attempted. Sits BETWEEN
+## [member balance_recovery_threshold] and [member balance_ragdoll_threshold]:
+## the character is past wobbling and heading toward a fall, but a well-placed step
+## could still save it. Above [member balance_ragdoll_threshold] it ragdolls instead.
+@export_range(0.0, 1.0) var stumble_step_threshold: float = 0.6
+## Base horizontal step distance (meters), scaled by balance ratio so a harder tip
+## takes a bigger step.
+@export_range(0.0, 1.0) var stumble_step_length: float = 0.35
+## Maximum horizontal reach of a step target from the foot's current position
+## (meters). Clamps the balance-scaled step so the leg never overstretches.
+@export_range(0.1, 1.5) var stumble_step_reach_max: float = 0.6
+## Time for the stepping foot to travel from its current position to the step
+## target (seconds).
+@export_range(0.05, 1.0) var stumble_step_duration: float = 0.25
+## Minimum time between consecutive stumble steps (seconds). Produces discrete
+## catch-steps rather than a foot sliding continuously.
+@export_range(0.0, 1.0) var stumble_step_cooldown: float = 0.3
+## Maximum number of catch-steps in one stagger before giving up and ragdolling.
+@export_range(1, 5) var stumble_max_steps: int = 2
+
+
 ## Creates a RagdollTuning with standard defaults. Equivalent to RagdollTuning.new()
 ## since all property defaults are pre-populated.
 static func create_default() -> RagdollTuning:

--- a/addons/kickback/stumble_planner.gd
+++ b/addons/kickback/stumble_planner.gd
@@ -1,0 +1,55 @@
+## Pure decision logic for stumble-step recovery (0.4.0 Self-Preservation).
+##
+## Stateless and side-effect-free: given a balance snapshot and the current foot
+## positions, it decides WHICH foot should step and WHERE the step target sits.
+## It deliberately owns none of the timing — the [ActiveRagdollController] owns the
+## stateful gating (trigger band, per-step cooldown, step count) and the
+## [FootIKSolver] owns execution (moving the foot to the target). Keeping the
+## decision pure means it is unit-testable without a live rig or physics step.
+##
+## A stumble step is the trailing foot swinging in the fall direction to catch a
+## loss of balance — the first *active* survival behavior. See
+## docs/SELF_PRESERVATION.md.
+class_name StumblePlanner
+extends RefCounted
+
+## Selects the foot that should step to catch a fall: the trailing foot, i.e. the
+## one the centre-of-mass is falling AWAY from. The load-bearing foot is the one
+## furthest in the fall ([param imbalance_dir]) direction and stays planted; the
+## other foot is free to swing. [param foot_positions] maps foot rig name → world
+## position. Returns "" when it cannot decide (no imbalance, fewer than two feet,
+## or degenerate positions coincident with the support centre).
+static func select_step_foot(imbalance_dir: Vector2, foot_positions: Dictionary,
+		support_center: Vector3) -> String:
+	if imbalance_dir.length_squared() < 0.0001 or foot_positions.size() < 2:
+		return ""
+	var dir := imbalance_dir.normalized()
+	var support_xz := Vector2(support_center.x, support_center.z)
+	var step_foot := ""
+	var lowest_dot := INF
+	for foot_rig: String in foot_positions:
+		var fp: Vector3 = foot_positions[foot_rig]
+		var off := Vector2(fp.x, fp.z) - support_xz
+		if off.length_squared() <= 0.0001:
+			continue
+		var d := off.normalized().dot(dir)
+		if d < lowest_dot:
+			lowest_dot = d
+			step_foot = foot_rig
+	return step_foot
+
+
+## Computes the world-space step target on the ground plane (pre ground-snap) for a
+## foot at [param foot_pos]: an offset from the foot's current position along the
+## fall direction ([param imbalance_dir]), with distance scaled by how far
+## off-balance the character is ([param balance_ratio]) and clamped to
+## [param reach_max]. The Y is left at the foot's current height — the caller
+## ground-snaps it via raycast during execution. Returns [param foot_pos]
+## unchanged when there is no fall direction to step along.
+static func compute_step_target(foot_pos: Vector3, imbalance_dir: Vector2,
+		balance_ratio: float, step_length: float, reach_max: float) -> Vector3:
+	if imbalance_dir.length_squared() < 0.0001:
+		return foot_pos
+	var dir := imbalance_dir.normalized()
+	var dist := clampf(step_length * maxf(balance_ratio, 0.0), 0.0, maxf(reach_max, 0.0))
+	return foot_pos + Vector3(dir.x, 0.0, dir.y) * dist

--- a/addons/kickback/stumble_planner.gd.uid
+++ b/addons/kickback/stumble_planner.gd.uid
@@ -1,0 +1,1 @@
+uid://oseatk0337su

--- a/test/test_stumble_planner.gd
+++ b/test/test_stumble_planner.gd
@@ -1,0 +1,87 @@
+## Tests for StumblePlanner — the pure decision logic behind stumble-step recovery
+## (0.4.0 Self-Preservation). No live rig: balance snapshots and foot positions in,
+## stepping foot and step target out. The stateful gating (cooldown, step count) and
+## execution live elsewhere and are covered by the integration tests.
+extends GutTest
+
+
+# ── select_step_foot ────────────────────────────────────────────────────────
+
+func test_picks_trailing_foot():
+	# Feet straddle the support centre on X; CoM falls toward +X (right foot leads).
+	# The trailing (left, -X) foot should step.
+	var feet := {
+		"Foot_L": Vector3(-0.15, 0.0, 0.0),
+		"Foot_R": Vector3(0.15, 0.0, 0.0),
+	}
+	var step := StumblePlanner.select_step_foot(Vector2(1, 0), feet, Vector3.ZERO)
+	assert_eq(step, "Foot_L", "trailing foot (away from fall direction) steps")
+
+
+func test_picks_trailing_foot_other_direction():
+	var feet := {
+		"Foot_L": Vector3(-0.15, 0.0, 0.0),
+		"Foot_R": Vector3(0.15, 0.0, 0.0),
+	}
+	var step := StumblePlanner.select_step_foot(Vector2(-1, 0), feet, Vector3.ZERO)
+	assert_eq(step, "Foot_R", "fall toward -X → right foot is trailing and steps")
+
+
+func test_no_step_without_imbalance():
+	var feet := {
+		"Foot_L": Vector3(-0.15, 0.0, 0.0),
+		"Foot_R": Vector3(0.15, 0.0, 0.0),
+	}
+	assert_eq(StumblePlanner.select_step_foot(Vector2.ZERO, feet, Vector3.ZERO), "",
+		"no fall direction → no step decision")
+
+
+func test_no_step_with_single_foot():
+	var feet := {"Foot_L": Vector3(-0.15, 0.0, 0.0)}
+	assert_eq(StumblePlanner.select_step_foot(Vector2(1, 0), feet, Vector3.ZERO), "",
+		"need two feet to choose a stepping foot")
+
+
+func test_step_foot_uses_support_center_offset():
+	# Both feet share +X sign but differ relative to a shifted support centre.
+	var feet := {
+		"Foot_L": Vector3(0.0, 0.0, 0.0),
+		"Foot_R": Vector3(0.30, 0.0, 0.0),
+	}
+	var support := Vector3(0.15, 0.0, 0.0)
+	var step := StumblePlanner.select_step_foot(Vector2(1, 0), feet, support)
+	assert_eq(step, "Foot_L", "trailing relative to support centre, not world origin")
+
+
+# ── compute_step_target ─────────────────────────────────────────────────────
+
+func test_target_offsets_along_fall_direction():
+	var t := StumblePlanner.compute_step_target(
+		Vector3(0, 0.5, 0), Vector2(1, 0), 1.0, 0.4, 0.6)
+	assert_almost_eq(t.x, 0.4, 0.0001, "x advances by step_length * balance_ratio")
+	assert_almost_eq(t.z, 0.0, 0.0001)
+
+
+func test_target_keeps_foot_height():
+	var t := StumblePlanner.compute_step_target(
+		Vector3(0, 0.73, 0), Vector2(0, 1), 1.0, 0.4, 0.6)
+	assert_almost_eq(t.y, 0.73, 0.0001, "Y unchanged — caller ground-snaps it")
+	assert_almost_eq(t.z, 0.4, 0.0001)
+
+
+func test_target_scales_with_balance_ratio():
+	var t := StumblePlanner.compute_step_target(
+		Vector3.ZERO, Vector2(1, 0), 0.5, 0.4, 0.6)
+	assert_almost_eq(t.x, 0.2, 0.0001, "half the imbalance → half the step")
+
+
+func test_target_clamped_to_reach_max():
+	var t := StumblePlanner.compute_step_target(
+		Vector3.ZERO, Vector2(1, 0), 1.5, 0.6, 0.6)
+	assert_almost_eq(t.x, 0.6, 0.0001, "step clamped to reach_max")
+
+
+func test_target_unchanged_without_imbalance():
+	var origin := Vector3(1, 0.5, 2)
+	var t := StumblePlanner.compute_step_target(origin, Vector2.ZERO, 1.0, 0.4, 0.6)
+	assert_eq(t, origin, "no fall direction → target is the foot's current position")

--- a/test/test_stumble_planner.gd.uid
+++ b/test/test_stumble_planner.gd.uid
@@ -1,0 +1,1 @@
+uid://cjpu1xqaxjgbf


### PR DESCRIPTION
## What

PR 2 of **0.4.0 Self-Preservation**. Adds the *pure decision core* for procedural stumble stepping — the first active survival behavior — plus its tuning surface. **No behavior change yet**: this is decision + tuning only; execution (driving the foot through the foot IK solver) and controller wiring land in the next PR.

Implements the design in [SELF_PRESERVATION.md](https://github.com/blugart-dev/kickback/blob/feat/0.4.0-self-preservation-kickoff/docs/SELF_PRESERVATION.md) (PR #83). Reflects the locked design decisions: configurable max steps (default 2), foot-placement-only.

## Changes

- **`addons/kickback/stumble_planner.gd`** (new) — `StumblePlanner`, stateless and side-effect-free:
  - `select_step_foot(imbalance_dir, foot_positions, support_center)` → the **trailing foot** (the one the CoM is falling *away* from; the load-bearing foot stays planted). Returns `""` when undecidable.
  - `compute_step_target(foot_pos, imbalance_dir, balance_ratio, step_length, reach_max)` → ground-plane step target, distance scaled by balance ratio and clamped to reach. Y left for the caller to ground-snap.
- **`RagdollTuning`** — new "Self-Preservation: Stumble Steps" group: `stumble_enabled`, `stumble_step_threshold` (sits between `balance_recovery_threshold` and `balance_ragdoll_threshold`), `stumble_step_length`, `stumble_step_reach_max`, `stumble_step_duration`, `stumble_step_cooldown`, `stumble_max_steps` (default 2).
- **`test/test_stumble_planner.gd`** (new) — 10 pure tests: trailing-foot selection (both directions, support-centre-relative), and target offset/scale/clamp/height-preservation.

## Why a pure planner

Keeping the decision free of timing and side effects makes it unit-testable without a live rig or physics step. The stateful gating (cooldown, step count, trigger band) belongs to the controller and the motion belongs to `FootIKSolver`; both are covered by integration/visual tests in PR3.

## Validation

- Headless import clean (exit 0); `StumblePlanner` registers.
- GUT suite **113 → 123**, all passing, 450 asserts. (The `tree_exiting` disconnect lines in CI logs are pre-existing Jolt joint-teardown noise from the rig harness — they print after "All tests passed".)

🤖 Generated with [Claude Code](https://claude.com/claude-code)