### PR TITLE
fix: foot-IK idle leg buzz (wrong leg orientation targets)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@
 > **Legacy history** below use the old, inconsistent numbering and are **not comparable**
 > to current versions.
 
+## [Unreleased]
+
+### Fixed
+- **Foot-IK idle leg buzz** — the two-bone IK solver built each leg segment's
+  orientation target from scratch with an assumed local-axis convention
+  (`_basis_looking_along` → `Basis(s, -d, f)`), which sat ~130° off the actual Mixamo
+  bone bases. The velocity spring then perpetually tried to twist the legs to those
+  joint-unreachable orientations, producing a sustained idle vibration (measured ~130°
+  upper-leg / 33° lower-leg target error, ~1–2 rad/s leg angular velocity on the ybot
+  asset at rest). The solver now expresses each segment's orientation as a **swing of
+  the animation basis** onto the IK bone direction (the same delta-from-animation
+  approach the foot already used for slope), so when no adjustment is needed the target
+  equals the animation pose (zero error). Result: target error drops to <2.5° and idle
+  leg buzz to ~0.2–0.5 rad/s. Convention-agnostic — it no longer assumes a Mixamo local
+  axis, so non-Mixamo rigs benefit too. Foot planting, pelvis drop, and leg lengths are
+  unchanged (positions were never altered). Removes `_basis_looking_along`; adds a
+  degeneracy-hardened `_swing` helper.
+
 ## [0.3.0] - 2026-06-19
 
 ### Changed

--- a/addons/kickback/foot_ik_solver.gd
+++ b/addons/kickback/foot_ik_solver.gd
@@ -290,7 +290,7 @@ func _solve_ik(delta: float, use_pins: bool) -> void:
 	# Solve left leg (use pinned XZ for foot target)
 	if _ik_weight_l > 0.01:
 		var ft := Vector3(foot_xz_l.x, gpos_l.y + _tuning.foot_ik_ankle_height, foot_xz_l.y)
-		var ik := _solve_two_bone_ik(upper_l.origin + ps, ft, lower_l.origin + ps, gnorm_l, foot_l)
+		var ik := _solve_two_bone_ik(upper_l, lower_l, foot_l, ft, gnorm_l, ps)
 		if not ik.is_empty():
 			_blend_leg(overrides, _upper_l, _lower_l, _foot_l,
 				upper_l, lower_l, foot_l, ik, _ik_weight_l, ps)
@@ -298,7 +298,7 @@ func _solve_ik(delta: float, use_pins: bool) -> void:
 	# Solve right leg
 	if _ik_weight_r > 0.01:
 		var ft := Vector3(foot_xz_r.x, gpos_r.y + _tuning.foot_ik_ankle_height, foot_xz_r.y)
-		var ik := _solve_two_bone_ik(upper_r.origin + ps, ft, lower_r.origin + ps, gnorm_r, foot_r)
+		var ik := _solve_two_bone_ik(upper_r, lower_r, foot_r, ft, gnorm_r, ps)
 		if not ik.is_empty():
 			_blend_leg(overrides, _upper_r, _lower_r, _foot_r,
 				upper_r, lower_r, foot_r, ik, _ik_weight_r, ps)
@@ -320,9 +320,20 @@ func _anim_global(bone_idx: int, sg: Transform3D) -> Transform3D:
 
 # ── Two-bone IK solver (law of cosines) ───────────────────────────────────
 
-func _solve_two_bone_ik(hip_pos: Vector3, foot_target: Vector3,
-		knee_hint: Vector3, ground_normal: Vector3,
-		foot_anim: Transform3D) -> Dictionary:
+## Solves the leg as a correction OF the animation pose: it computes where the
+## knee/foot should go (positions, via law of cosines) and then expresses each
+## segment's orientation as a SWING of that segment's animation basis onto the new
+## bone direction. This is convention-agnostic — when the IK direction equals the
+## animation direction (no adjustment needed), the swing is identity and the target
+## equals the animation pose, so there is no spurious rotation error for the spring
+## to chase. (Building bases from scratch with an assumed local-axis convention
+## produced ~130° steady orientation errors against Mixamo bones → idle leg buzz.)
+## [param upper_anim]/[param lower_anim]/[param foot_anim] are world-space animation
+## globals; [param ps] is the pelvis shift applied to the position chain.
+func _solve_two_bone_ik(upper_anim: Transform3D, lower_anim: Transform3D,
+		foot_anim: Transform3D, foot_target: Vector3, ground_normal: Vector3,
+		ps: Vector3) -> Dictionary:
+	var hip_pos := upper_anim.origin + ps
 	var cv := foot_target - hip_pos
 	var cl := cv.length()
 	var mx := _upper_leg_len + _lower_leg_len - 0.01
@@ -336,7 +347,9 @@ func _solve_two_bone_ik(hip_pos: Vector3, foot_target: Vector3,
 	ch = clampf(ch, -1.0, 1.0)
 	var ho := acos(ch)
 
-	# Knee direction from hint
+	# Bend plane from the animation knee direction (keeps the knee bending the way
+	# the animation already does).
+	var knee_hint := lower_anim.origin + ps
 	var cd := cv.normalized()
 	var kf := (knee_hint - hip_pos).normalized()
 	var side := cd.cross(kf).normalized()
@@ -346,17 +359,19 @@ func _solve_two_bone_ik(hip_pos: Vector3, foot_target: Vector3,
 		side = cd.cross(Vector3.RIGHT).normalized()
 	var bd := side.cross(cd).normalized()
 
-	# Upper and lower leg positions
+	# Upper/lower leg directions and the knee position between them.
 	var ud := (cd * cos(ho) + bd * sin(ho)).normalized()
 	var kp := hip_pos + ud * _upper_leg_len
 	var ld := (foot_target - kp).normalized()
 
-	# Build transforms
-	var ux := Transform3D(_basis_looking_along(ud, side), hip_pos)
-	var lx := Transform3D(_basis_looking_along(ld, side), kp)
+	# Orientation as a swing of the animation basis onto the new bone direction.
+	var anim_upper_dir := (lower_anim.origin - upper_anim.origin).normalized()
+	var anim_lower_dir := (foot_anim.origin - lower_anim.origin).normalized()
+	var ux := Transform3D(Basis(_swing(anim_upper_dir, ud)) * upper_anim.basis, hip_pos)
+	var lx := Transform3D(Basis(_swing(anim_lower_dir, ld)) * lower_anim.basis, kp)
 
-	# Foot rotation: apply slope delta to animation pose
-	# On flat ground (normal=UP) this is identity — no correction
+	# Foot rotation: apply slope delta to the animation pose.
+	# On flat ground (normal=UP) this is identity — no correction.
 	var slope_correction := Quaternion(Vector3.UP, ground_normal.normalized())
 	var fb := Basis(slope_correction) * foot_anim.basis
 	var fx := Transform3D(fb, foot_target)
@@ -364,13 +379,23 @@ func _solve_two_bone_ik(hip_pos: Vector3, foot_target: Vector3,
 	return {"upper": ux, "lower": lx, "foot": fx}
 
 
-func _basis_looking_along(dir: Vector3, hint_side: Vector3) -> Basis:
-	var d := dir.normalized()
-	var s := d.cross(Vector3.UP).normalized()
-	if s.length_squared() < 0.001:
-		s = hint_side.normalized()
-	var f := s.cross(d).normalized()
-	return Basis(s, -d, f)
+## Shortest-arc rotation from [param from] to [param to], hardened against the zero
+## and antiparallel degeneracies that the bare Quaternion(from, to) constructor
+## asserts on.
+func _swing(from: Vector3, to: Vector3) -> Quaternion:
+	if from.length_squared() < 0.0001 or to.length_squared() < 0.0001:
+		return Quaternion.IDENTITY
+	var f := from.normalized()
+	var t := to.normalized()
+	var d := f.dot(t)
+	if d > 0.9999:
+		return Quaternion.IDENTITY
+	if d < -0.9999:
+		var axis := f.cross(Vector3.UP)
+		if axis.length_squared() < 0.0001:
+			axis = f.cross(Vector3.RIGHT)
+		return Quaternion(axis.normalized(), PI)
+	return Quaternion(f, t)
 
 
 # ── Leg blend helper ───────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Fixes the **idle leg vibration** in foot IK — a latent 0.3.0 quality bug surfaced while validating the (now-parked) 0.4.0 stumble work. **Substrate hardening; lands on `main` before 0.4.0 resumes.**

## Root cause (data-backed)

The two-bone IK solver built each leg segment's orientation target *from scratch* with an assumed local-axis convention (`_basis_looking_along` → `Basis(s, -d, f)`). That convention sits **~130° off the real Mixamo bone bases**. The velocity spring then perpetually tried to twist the legs to those joint-*unreachable* orientations → sustained idle buzz.

Measured headlessly on the **real ybot asset** at rest (target error = angle between the IK target basis and the actual bone; ang vel = idle angular velocity):

| Bone | target error before → after | idle ang. vel before → after |
|---|---|---|
| UpperLeg | **130° → 0.6°** | 1.1 → **0.17** rad/s |
| LowerLeg | 33° → 1.0° | 1.8 → **0.52** rad/s |
| Foot | 11° → 2.4° | 1.7 → **1.17** rad/s |

(The investigation also confirmed the **velocity-spring core is sound** — it tracks consistent targets calmly and is the same formula Jolt's own `DriveToPoseUsingKinematics` uses. It was faithfully chasing garbage targets, not malfunctioning.)

## The fix

Express each leg segment's orientation as a **swing of its animation basis** onto the new IK bone direction — the same delta-from-animation approach the *foot* already used for slope correction (and why the foot's error was smallest). When the IK direction equals the animation direction (no adjustment needed), the swing is identity, so the target **equals the animation pose → zero error**.

- Convention-agnostic: no longer assumes a Mixamo local axis, so **non-Mixamo rigs benefit too** (aligns with the role-based generality work).
- **Positions unchanged** — knee, foot target, and pelvis drop are untouched; only segment *orientations* are corrected. Foot planting / pelvis / leg-length behavior is identical.
- Removes `_basis_looking_along`; adds a degeneracy-hardened `_swing` helper.

## Validation

- Headless measurement above (target error 130° → <2.5°; leg buzz ~collapsed).
- **GUT 113/113** — all existing foot-IK tests (planting, pelvis-never-lifts, leg lengths, role-mapped non-Mixamo) still pass.
- Visual in-editor confirmation pending (idle legs should be calm).

## Note

The remaining ~1 rad/s residual on the foot is the spring's steady-state floor — addressed by the separate **spring-hardening** PR (settle deadband + solver-cooperative velocity), the second half of the substrate hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)