### PR TITLE
fix: spring settle deadband — kill the steady-state buzz floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@
   axis, so non-Mixamo rigs benefit too. Foot planting, pelvis drop, and leg lengths are
   unchanged (positions were never altered). Removes `_basis_looking_along`; adds a
   degeneracy-hardened `_swing` helper.
+- **Spring steady-state buzz floor** — the velocity spring converts pose error to
+  corrective velocity via `error × 60 Hz`, so any tiny *irreducible* error (e.g. a
+  planted foot the joints can't perfectly satisfy, or any slightly-imperfect target a
+  future active behavior feeds) was amplified into sustained velocity every tick — a
+  residual buzz, worst on low-strength chain-end bodies like the foot. Added a **settle
+  deadband** (`spring_angular_settle_deadband` ≈ 2.3°, `spring_linear_settle_deadband`
+  ≈ 4 mm): the spring commands zero corrective velocity within the deadband and ramps in
+  proportionally above it, so near-equilibrium error settles instead of buzzing.
+  Negligible for the large errors of real motion / hit reactions. On the ybot asset this
+  drops idle foot angular velocity from ~1.2 to ~0.18 rad/s (whole leg ≤0.31). This
+  hardens the substrate generally — every spring-target-driven behavior (foot IK, and
+  the future stumble/brace work) tolerates imperfect targets without buzzing. The
+  velocity-spring model itself is unchanged and sound (it matches Jolt's own
+  `DriveToPoseUsingKinematics`); this only stops it amplifying sub-threshold error.
 
 ## [0.3.0] - 2026-06-19
 

--- a/addons/kickback/resources/ragdoll_tuning.gd
+++ b/addons/kickback/resources/ragdoll_tuning.gd
@@ -220,6 +220,16 @@ extends Resource
 @export var spring_linear_damp_base: float = 0.5
 ## Linear damping scale factor per strength ratio.
 @export var spring_linear_damp_scale: float = 1.5
+## Angular settle deadband (radians). The spring commands NO corrective angular
+## velocity while a bone is within this much of its target orientation, then ramps
+## in proportionally above it. Kills the steady-state buzz where a tiny irreducible
+## error (e.g. a planted foot the joints can't perfectly satisfy) is otherwise
+## amplified into sustained velocity every tick. Negligible during real motion/hits
+## (errors are far larger). 0.0 = disabled. ~0.04 rad ≈ 2.3°.
+@export_range(0.0, 0.2) var spring_angular_settle_deadband: float = 0.04
+## Linear settle deadband (meters). Position-spring analogue of
+## [member spring_angular_settle_deadband]. 0.0 = disabled.
+@export_range(0.0, 0.05) var spring_linear_settle_deadband: float = 0.004
 
 # ── Advanced: Directional Bracing ───────────────────────────────────────────
 

--- a/addons/kickback/spring_resolver.gd
+++ b/addons/kickback/spring_resolver.gd
@@ -167,7 +167,13 @@ func _physics_process(delta: float) -> void:
 		if pin_injury > 0.0:
 			pin *= (1.0 - pin_injury * _tuning.injury_pin_impact)
 		var pos_error := target_xform.origin - current_xform.origin
-		body.linear_velocity = body.linear_velocity.lerp(pos_error * _REFERENCE_HZ, _fr_weight(pin, delta))
+		# Linear settle deadband (see _apply_angular_spring): zero corrective velocity
+		# within the deadband, ramping in above it, to kill the position-spring buzz floor.
+		var dist := pos_error.length()
+		var lin_target := Vector3.ZERO
+		if dist > 0.0001:
+			lin_target = pos_error * (maxf(dist - _tuning.spring_linear_settle_deadband, 0.0) / dist) * _REFERENCE_HZ
+		body.linear_velocity = body.linear_velocity.lerp(lin_target, _fr_weight(pin, delta))
 
 		if body.angular_velocity.length_squared() > _max_angular_vel_sq:
 			body.angular_velocity = body.angular_velocity.normalized() * _tuning.max_angular_velocity
@@ -194,7 +200,13 @@ func _apply_angular_spring(body: RigidBody3D, target: Transform3D, current: Tran
 	if axis_raw.length_squared() < 0.0001 or angle < 0.001:
 		return
 
-	var target_vel := (axis_raw.normalized() * angle) * _REFERENCE_HZ
+	# Settle deadband: command NO correction within the deadband, then ramp in
+	# proportionally above it. A tiny irreducible steady-state error (e.g. a planted
+	# foot the joints can't perfectly satisfy) would otherwise be amplified by the
+	# ×_REFERENCE_HZ conversion into sustained velocity every tick — the idle buzz.
+	# Negligible for the large errors of real motion / hit reactions.
+	var eff_angle := maxf(angle - _tuning.spring_angular_settle_deadband, 0.0)
+	var target_vel := (axis_raw.normalized() * eff_angle) * _REFERENCE_HZ
 	body.angular_velocity = body.angular_velocity.lerp(target_vel, _fr_weight(strength, delta))
 
 


### PR DESCRIPTION
## What

Second half of the substrate hardening (the first half, the foot-IK orientation fix, landed in #86). Eliminates the **residual foot wobble** — the spring's steady-state buzz floor. (Re-opened as a fresh PR against `main` after #86's branch deletion auto-closed the original stacked #87; diff is now just the deadband.)

## Root cause

The velocity spring converts pose error to corrective velocity via `error × 60 Hz`, so any *irreducible* steady-state error (a planted foot the joints can't perfectly satisfy, or any slightly-imperfect target a future behavior feeds) is amplified into sustained velocity every tick — worst on the foot (lowest spring strength, collider disabled during NORMAL). Re-enabling the foot collider was ruled out (makes errors *worse* — 25° / 9–20 cm as the foot fights the ground).

## The fix

A **settle deadband** on the angular and linear springs: zero corrective velocity within the deadband, ramping in above it. New tunables `spring_angular_settle_deadband` (≈2.3°) and `spring_linear_settle_deadband` (≈4 mm), read from tuning in the spring loop. Negligible for the large errors of real motion / hit reactions.

## Result (real ybot, idle)

| Bone | deadband off → on |
|---|---|
| UpperLeg | 0.19 → 0.10 rad/s |
| LowerLeg | 0.51 → 0.31 rad/s |
| **Foot** | **1.20 → 0.18 rad/s** |

Foot buzz across the whole effort: **1.7 (0.3.0) → 1.2 (#86) → 0.18 (this)**. User visually confirmed calm idle + intact reactions.

Hardens the substrate generally — every spring-target-driven behavior (foot IK, and the parked stumble/brace work) now tolerates imperfect targets without buzzing. The velocity-spring model is unchanged and sound (matches Jolt's `DriveToPoseUsingKinematics`); this only stops it amplifying sub-threshold error.

## Validation

GUT 113/113 (incl. `test_spring_math` + runtime spring tracking). Headless measurement above. Visually confirmed in the shooting-range demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)