### PR TITLE
feat: directed stumble — first active survival reaction (0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@
 
 ## [Unreleased]
 
+### Added
+- **Directed stumble** (0.4.0 Self-Preservation) — the first *active* survival reaction.
+  A staggering hit now visibly **shoves the character**: the root drifts along the hit
+  direction (`stumble_push_speed`/`stumble_push_decel`) so the reaction *displaces* it,
+  the **trailing foot steps** to follow — placed ahead of the hips, kept in its own lane
+  (no crossing), and lifted along an arc (`stumble_step_lift`) so it steps rather than
+  slides — and the **lower body stiffens** (`stumble_brace_strength`) to stay upright
+  while the **upper body stays loose** and reacts to the momentum. The character commits
+  to the reaction (the tip-over→ragdoll transition is suspended while stumbling) and ends
+  up at a new position before recovering to idle; strong hits still ragdoll, light hits
+  just wobble. New `RagdollTuning` "Self-Preservation: Stumble Steps" group;
+  `FootIKSolver.begin_stumble()`/`is_stepping()` (reusing the stagger pin/IK plumbing);
+  `stumble_step_started(foot_rig, target)` signal. Design + the emergent→directed pivot
+  recorded in [docs/SELF_PRESERVATION.md](docs/SELF_PRESERVATION.md); `0.4.0` marked in
+  progress in [ROADMAP.md](docs/ROADMAP.md). Arm bracing (the upper-body active layer) is
+  next.
+
 ### Fixed
 - **Foot-IK idle leg buzz** — the two-bone IK solver built each leg segment's
   orientation target from scratch with an assumed local-axis convention

--- a/addons/kickback/active_ragdoll_controller.gd
+++ b/addons/kickback/active_ragdoll_controller.gd
@@ -58,6 +58,11 @@ var _ragdoll_poses: Dictionary = {}  # rig_name → Transform3D at recovery star
 var _stagger_elapsed: float = 0.0
 var _stagger_hit_dir: Vector3 = Vector3.ZERO
 var _balance_stable_timer: float = 0.0
+var _stumble_step_count: int = 0  # Steps taken this stumble (vs stumble_max_steps).
+var _stumbling: bool = false  # In an active directed stumble (suspends tip-over ragdoll).
+var _stumble_dir: Vector3 = Vector3.ZERO  # Horizontal knockback direction of the stumble.
+var _stumble_drift: float = 0.0  # Current knockback drift speed (m/s), decays to 0.
+var _stumble_dist_since_step: float = 0.0  # Drift distance accumulated toward the next step.
 var _fatigue: float = 0.0
 var _pain: float = 0.0
 var _last_hit_time: float = 0.0
@@ -115,6 +120,10 @@ signal threat_anticipated(direction: Vector3, urgency: float)
 ## Emitted when a bone region sustains injury from a significant hit.
 ## Injuries persist longer than spring recovery and cause functional impairment.
 signal region_injured(rig_name: String, severity: float)
+## Emitted when a stumble recovery step begins during stagger. [param foot_rig] is
+## the stepping foot; [param target] is the world-space step goal. Connect for step
+## footstep SFX or a step animation hint. (0.4.0 Self-Preservation.)
+signal stumble_step_started(foot_rig: String, target: Vector3)
 
 
 func configure(profile: RagdollProfile, tuning: RagdollTuning) -> void:
@@ -322,11 +331,18 @@ func _update_stagger(delta: float) -> void:
 	var has_support: bool = balance_state.has_support
 	balance_changed.emit(balance)
 
+	# Directed stumble: a staggering hit knocks the character along the hit direction
+	# (visible displacement) with the feet stepping to follow, while the body stiffens
+	# to stay upright. Runs regardless of measured support (it's hit-driven, not
+	# balance-driven) and COMMITS — the tip-over→ragdoll transition is suspended while
+	# stumbling so the reaction plays out instead of collapsing mid-step.
+	_update_directed_stumble(delta)
+
 	if has_support:
-		# Too far off-balance → ragdoll (tipping over). Hard cap: if the budget
-		# denies the slot, keep fighting in stagger instead of a full fall — and
-		# retry on later frames, so it ragdolls as soon as a slot frees up.
-		if balance > _tuning.balance_ragdoll_threshold:
+		# Too far off-balance → ragdoll (tipping over), unless mid-stumble. Hard cap: if
+		# the budget denies the slot, keep fighting in stagger instead of a full fall —
+		# and retry on later frames, so it ragdolls as soon as a slot frees up.
+		if balance > _tuning.balance_ragdoll_threshold and not _stumbling:
 			if _try_acquire_ragdoll_slot():
 				_full_ragdoll()
 				return
@@ -343,6 +359,100 @@ func _update_stagger(delta: float) -> void:
 	# Fallback: timer-based stagger end (safety net, and the sole exit without support)
 	if _stagger_elapsed >= _tuning.stagger_duration:
 		_finish_stagger()
+
+
+## Drives the directed stumble (0.4.0 Self-Preservation): a staggering hit knocks the
+## character root along the hit direction so the reaction visibly DISPLACES it, with
+## the feet stepping to follow and the body stiffening to stay upright. The drift
+## decays (momentum absorbed) over [member RagdollTuning.stumble_push_decel]; a step
+## fires every [member RagdollTuning.stumble_step_length] of travel (trailing foot,
+## up to [member RagdollTuning.stumble_max_steps]). Ends when the drift is spent and no
+## step is in flight. While stumbling ([member _stumbling]) the caller suspends the
+## tip-over→ragdoll transition so the reaction plays out. No-op without foot-IK pinning.
+func _update_directed_stumble(delta: float) -> void:
+	if not _stumbling:
+		return
+	if not _tuning.stumble_enabled or not _foot_ik or not _character_root:
+		_stumbling = false
+		return
+
+	# Drift the root along the hit direction (horizontal), decaying the speed.
+	if _stumble_drift > 0.01:
+		var step_move := _stumble_dir * _stumble_drift * delta
+		_character_root.global_position += step_move
+		_stumble_dist_since_step += step_move.length()
+		_stumble_drift = maxf(_stumble_drift - _tuning.stumble_push_decel * delta, 0.0)
+
+	# Pace a step every step_length of travel so the feet keep up with the body.
+	if _stumble_step_count < _tuning.stumble_max_steps \
+			and _stumble_dist_since_step >= _tuning.stumble_step_length \
+			and not _foot_ik.is_stepping():
+		_do_directed_step()
+		_stumble_dist_since_step = 0.0
+
+	# Stiffen the lower body so it stays upright as it lurches, while the upper body
+	# stays loose and reacts (differential stiffness — see _apply_stumble_brace).
+	_apply_stumble_brace()
+
+	# Stumble is over once the momentum is spent and the last step has planted.
+	if _stumble_drift <= 0.01 and not _foot_ik.is_stepping():
+		_stumbling = false
+
+
+## Steps the trailing foot (the one furthest back along the stumble direction) forward
+## in that direction, through the foot IK solver. Returns nothing; bumps the step count
+## and emits [signal stumble_step_started] when a step starts.
+func _do_directed_step() -> void:
+	var bodies := _rig_builder.get_bodies()
+	var step_foot := ""
+	var lowest := INF
+	var dir2 := Vector2(_stumble_dir.x, _stumble_dir.z)
+	for foot_rig: String in _foot_rigs:
+		var fb: RigidBody3D = bodies.get(foot_rig)
+		if not fb:
+			continue
+		var d := Vector2(fb.global_position.x, fb.global_position.z).dot(dir2)
+		if d < lowest:
+			lowest = d
+			step_foot = foot_rig
+	if step_foot.is_empty():
+		return
+	var fb: RigidBody3D = bodies[step_foot]
+
+	# Place the step ahead of the HIPS in the stumble direction, but PRESERVE the
+	# foot's lateral offset (its left/right side of the body) so the feet stay in their
+	# own lanes and don't cross. Plant a step ahead of the body so it catches the drift.
+	var hips: RigidBody3D = bodies.get(_root_rig)
+	var center: Vector3 = hips.global_position if hips else fb.global_position
+	var perp := Vector3(-_stumble_dir.z, 0.0, _stumble_dir.x)  # 90° in the ground plane
+	var lateral := (fb.global_position - center).dot(perp)  # signed offset onto this foot's side
+	var target := center + _stumble_dir * _tuning.stumble_step_length + perp * lateral
+	target.y = fb.global_position.y  # the foot IK ground-snaps + lifts this
+	if _foot_ik.begin_stumble(step_foot, target, _tuning.stumble_step_duration):
+		_stumble_step_count += 1
+		stumble_step_started.emit(step_foot, target)
+
+
+## Differential stiffening while stumbling. Braces only the LOWER body (leg chains +
+## pelvis) toward base so it steps and holds the character upright — but deliberately
+## leaves the upper body (torso, arms, head) at the stagger floor so it stays LOOSE and
+## reacts to the hit impulse and the stumble momentum. That contrast (purposeful legs,
+## flailing upper body) is what reads as a live body caught off guard, rather than a
+## rigid mannequin sliding on stepping feet. Transient — applied only while
+## [member _stumbling]; strengths relax to the floor when the stumble ends.
+func _apply_stumble_brace() -> void:
+	var brace: float = _tuning.stumble_brace_strength
+	if brace <= 0.0:
+		return
+	for rig_name: String in _spring.get_all_bone_names():
+		if _is_bone_protected(rig_name):
+			continue
+		# Lower body only — legs (stepping + support) and the pelvis (root upright).
+		if not (_is_leg_bone(rig_name) or rig_name == _root_rig):
+			continue
+		var target := _effective_base_strength(rig_name) * brace
+		if _spring.get_bone_strength(rig_name) < target:
+			_spring.set_bone_strength(rig_name, target)
 
 
 func _update_ragdoll(delta: float) -> void:
@@ -821,6 +931,8 @@ func _start_stagger(hit_dir: Vector3) -> void:
 	_state = State.STAGGER
 	_stagger_elapsed = 0.0
 	_balance_stable_timer = 0.0
+	_stumble_step_count = 0
+	_stumbling = false
 	_reaction_pulses.clear()
 
 	# Moving characters stagger in their movement direction, not just hit direction
@@ -833,6 +945,20 @@ func _start_stagger(hit_dir: Vector3) -> void:
 	_com_initialized = false
 	_sway_phase = randf() * TAU
 	_spring.recovery_rate = _tuning.stagger_recovery_rate
+
+	# Begin a directed stumble: knock the character along the hit direction so the
+	# reaction visibly DISPLACES it, with the feet stepping to follow. The horizontal
+	# hit direction drives both the drift and the step direction.
+	_stumble_dir = Vector3(hit_dir.x, 0.0, hit_dir.z)
+	if _tuning.stumble_enabled and _foot_ik and _character_root and _stumble_dir.length() > 0.01:
+		_stumble_dir = _stumble_dir.normalized()
+		_stumble_drift = _tuning.stumble_push_speed
+		_stumble_dist_since_step = _tuning.stumble_step_length  # step on the first frame
+		_stumbling = true
+	else:
+		_stumble_dir = Vector3.ZERO
+		_stumble_drift = 0.0
+		_stumbling = false
 
 	if _tuning.brace_strength_bonus > 0.0:
 		_apply_directional_bracing(hit_dir)
@@ -852,6 +978,8 @@ func _finish_stagger() -> void:
 	_state = State.NORMAL
 	_balance_stable_timer = 0.0
 	_com_initialized = false
+	_stumbling = false
+	_stumble_drift = 0.0
 	_spring.recovery_rate = _spring.get_default_recovery_rate()
 	_disable_normal_collisions()
 	state_changed.emit(_state)

--- a/addons/kickback/foot_ik_solver.gd
+++ b/addons/kickback/foot_ik_solver.gd
@@ -47,6 +47,21 @@ var _stagger_pinning: bool = false
 var _pin_pos_l: Vector3 = Vector3.ZERO
 var _pin_pos_r: Vector3 = Vector3.ZERO
 
+# Stumble stepping (0.4.0 Self-Preservation): animate a pinned foot's target from
+# its current position to a step goal over a duration, then hold (the foot is now
+# planted at the new spot). Only XZ matters — the solve ground-snaps Y by raycast.
+var _step_active_l: bool = false
+var _step_active_r: bool = false
+var _step_from_l: Vector3 = Vector3.ZERO
+var _step_from_r: Vector3 = Vector3.ZERO
+var _step_to_l: Vector3 = Vector3.ZERO
+var _step_to_r: Vector3 = Vector3.ZERO
+var _step_t_l: float = 0.0
+var _step_t_r: float = 0.0
+var _step_lift_l: float = 0.0  # Current vertical lift of the swinging left foot (m).
+var _step_lift_r: float = 0.0
+var _step_duration: float = 0.25
+
 # Per-solve scratch buffers, reused to avoid per-frame allocations.
 #   _anim_cache:   bone_idx → world-space animation global, rebuilt each solve so
 #                  no bone's parent chain is walked more than once per frame.
@@ -155,6 +170,7 @@ func process_stagger(delta: float) -> void:
 	if not _stagger_pinning:
 		_blend_out(delta)
 		return
+	_advance_steps(delta)
 	_disable_foot_collision()
 	_boost_leg_strength()
 	_solve_ik(delta, true)
@@ -162,6 +178,72 @@ func process_stagger(delta: float) -> void:
 
 func end_stagger() -> void:
 	_stagger_pinning = false
+	_clear_steps()
+
+
+# ── Stumble stepping (0.4.0 Self-Preservation) ─────────────────────────────
+
+## Starts a stumble recovery step: the foot named [param foot_rig] swings from its
+## current pinned position to [param target] (a world-space ground-plane goal) over
+## [param duration] seconds, with a lift arc, then stays planted there. The controller
+## decides when, which foot, and where (the directed stumble); this just animates the
+## foot pin.
+## Requires stagger pinning to be active (the foot must be pinned to move it).
+## Returns true if the step started, false if it can't (not pinning, or the foot
+## isn't one of this rig's two feet).
+func begin_stumble(foot_rig: String, target: Vector3, duration: float) -> bool:
+	if not _initialized or not _stagger_pinning:
+		return false
+	_step_duration = maxf(duration, 0.01)
+	if foot_rig == _foot_l:
+		_step_from_l = _pin_pos_l
+		_step_to_l = target
+		_step_t_l = 0.0
+		_step_active_l = true
+		return true
+	if foot_rig == _foot_r:
+		_step_from_r = _pin_pos_r
+		_step_to_r = target
+		_step_t_r = 0.0
+		_step_active_r = true
+		return true
+	return false
+
+
+## True while either foot is mid-step.
+func is_stepping() -> bool:
+	return _step_active_l or _step_active_r
+
+
+## Advances any active step, moving the foot's pin target from→to over the step
+## duration with a smoothstep ease, then planting it at the goal.
+func _advance_steps(delta: float) -> void:
+	# Lift height arc: the swinging foot rises and falls (sin over the step) so it
+	# STEPS over the ground instead of sliding across it.
+	var lift_h: float = _tuning.stumble_step_lift
+	if _step_active_l:
+		_step_t_l = minf(_step_t_l + delta / _step_duration, 1.0)
+		_pin_pos_l = _step_from_l.lerp(_step_to_l, smoothstep(0.0, 1.0, _step_t_l))
+		_step_lift_l = sin(_step_t_l * PI) * lift_h
+		if _step_t_l >= 1.0:
+			_pin_pos_l = _step_to_l
+			_step_active_l = false
+			_step_lift_l = 0.0
+	if _step_active_r:
+		_step_t_r = minf(_step_t_r + delta / _step_duration, 1.0)
+		_pin_pos_r = _step_from_r.lerp(_step_to_r, smoothstep(0.0, 1.0, _step_t_r))
+		_step_lift_r = sin(_step_t_r * PI) * lift_h
+		if _step_t_r >= 1.0:
+			_pin_pos_r = _step_to_r
+			_step_active_r = false
+			_step_lift_r = 0.0
+
+
+func _clear_steps() -> void:
+	_step_active_l = false
+	_step_active_r = false
+	_step_lift_l = 0.0
+	_step_lift_r = 0.0
 
 
 func _blend_out(delta: float) -> void:
@@ -182,6 +264,7 @@ func reset() -> void:
 	_ik_weight_r = 0.0
 	_pelvis_offset = 0.0
 	_stagger_pinning = false
+	_clear_steps()
 	_restore_foot_collision()
 
 
@@ -289,7 +372,7 @@ func _solve_ik(delta: float, use_pins: bool) -> void:
 
 	# Solve left leg (use pinned XZ for foot target)
 	if _ik_weight_l > 0.01:
-		var ft := Vector3(foot_xz_l.x, gpos_l.y + _tuning.foot_ik_ankle_height, foot_xz_l.y)
+		var ft := Vector3(foot_xz_l.x, gpos_l.y + _tuning.foot_ik_ankle_height + _step_lift_l, foot_xz_l.y)
 		var ik := _solve_two_bone_ik(upper_l, lower_l, foot_l, ft, gnorm_l, ps)
 		if not ik.is_empty():
 			_blend_leg(overrides, _upper_l, _lower_l, _foot_l,
@@ -297,7 +380,7 @@ func _solve_ik(delta: float, use_pins: bool) -> void:
 
 	# Solve right leg
 	if _ik_weight_r > 0.01:
-		var ft := Vector3(foot_xz_r.x, gpos_r.y + _tuning.foot_ik_ankle_height, foot_xz_r.y)
+		var ft := Vector3(foot_xz_r.x, gpos_r.y + _tuning.foot_ik_ankle_height + _step_lift_r, foot_xz_r.y)
 		var ik := _solve_two_bone_ik(upper_r, lower_r, foot_r, ft, gnorm_r, ps)
 		if not ik.is_empty():
 			_blend_leg(overrides, _upper_r, _lower_r, _foot_r,

--- a/addons/kickback/resources/ragdoll_tuning.gd
+++ b/addons/kickback/resources/ragdoll_tuning.gd
@@ -358,6 +358,55 @@ extends Resource
 @export_range(0.1, 1.0) var foot_ik_stagger_leg_strength: float = 0.4
 
 
+# ── Self-Preservation: Stumble Steps ────────────────────────────────────────
+
+@export_group("Self-Preservation: Stumble Steps")
+## Enable procedural stumble stepping: during STAGGER, the trailing foot swings in
+## the fall direction to catch a loss of balance before it becomes a fall.
+## Requires foot IK (the step is executed through the foot IK solver). 0.4.0.
+@export var stumble_enabled: bool = true
+## Balance ratio above which a stumble catch begins. Sits BETWEEN
+## [member balance_recovery_threshold] and [member balance_ragdoll_threshold]:
+## the character is past wobbling and heading toward a fall, but a step could still
+## save it. Set low enough that the catch STARTS before the centre-of-mass is already
+## lost — once a catch is in progress the tip-over→ragdoll transition is suspended
+## (the character commits to the attempt) until balance recovers or the step budget
+## ([member stumble_max_steps]) runs out.
+@export_range(0.0, 1.0) var stumble_step_threshold: float = 0.45
+## Base horizontal step distance (meters), scaled by balance ratio so a harder tip
+## takes a bigger step.
+@export_range(0.0, 1.0) var stumble_step_length: float = 0.35
+## Maximum horizontal reach of a step target from the foot's current position
+## (meters). Clamps the balance-scaled step so the leg never overstretches.
+@export_range(0.1, 1.5) var stumble_step_reach_max: float = 0.6
+## Time for the stepping foot to travel from its current position to the step
+## target (seconds).
+@export_range(0.05, 1.0) var stumble_step_duration: float = 0.25
+## Minimum time between consecutive stumble steps (seconds). Produces discrete
+## catch-steps rather than a foot sliding continuously.
+@export_range(0.0, 1.0) var stumble_step_cooldown: float = 0.3
+## Maximum number of catch-steps in one stagger before giving up and ragdolling.
+@export_range(1, 5) var stumble_max_steps: int = 2
+## Spring strength (as a fraction of each bone's base) applied WHILE stumbling. A
+## real stumble tenses the body and steps — not a foot reposition on a limp ragdoll —
+## so during the stumble the springs stiffen toward this level so the body stays
+## upright as it lurches. Transient (only while [member _stumbling]); relaxes to the
+## stagger floor when the stumble ends. Higher = stiffer/more upright; too high reads
+## as a snap. 0.0 = no stiffening.
+@export_range(0.0, 1.0) var stumble_brace_strength: float = 0.7
+## Initial knockback speed (m/s) of the directed stumble: on a staggering hit the
+## character root drifts in the hit direction at this speed, so the stumble visibly
+## DISPLACES the character (you stumble where you're shoved) rather than shuffling in
+## place. Decays via [member stumble_push_decel]. 0.0 = no displacement (in-place).
+@export_range(0.0, 6.0) var stumble_push_speed: float = 2.0
+## Deceleration (m/s²) of the knockback drift — how fast the stumble momentum is
+## absorbed. Total stumble distance ≈ speed² / (2·decel). Higher = shorter stumble.
+@export_range(0.5, 20.0) var stumble_push_decel: float = 7.0
+## Peak height (meters) the swinging foot lifts during a stumble step, so it steps
+## over the ground instead of sliding across it. 0.0 = no lift (slides).
+@export_range(0.0, 0.3) var stumble_step_lift: float = 0.1
+
+
 ## Creates a RagdollTuning with standard defaults. Equivalent to RagdollTuning.new()
 ## since all property defaults are pre-populated.
 static func create_default() -> RagdollTuning:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -29,7 +29,7 @@ figure is **~30%**.)
 | Version | Theme | Delivers |
 |---------|-------|----------|
 | **0.3.x** | Re-baseline + hardening | Honest docs & scorecard, plus the hardening batch: fixed silent multi-rig degradation, wired the budget manager (hard cap), added runtime smoke tests, generalized beyond Mixamo, and migrated `PhysicsRigSync` to a `SkeletonModifier3D`. See *Known hardening items* for what's resolved vs still open. |
-| **0.4.0** | Self-Preservation | Procedural stumble steps + arm bracing — the first *active* survival behaviors. |
+| **0.4.0** 🚧 | Self-Preservation | Directed stumble (shipped) + arm bracing (next) — the first *active* survival behaviors. **In progress** — see [SELF_PRESERVATION.md](SELF_PRESERVATION.md). |
 | **0.5.0** | Environmental Awareness | Wall/surface bracing + ground crawling. |
 | **0.6.0** | World Interaction | Environmental grabbing (IK reach + physics pins to grab points). |
 | **0.7.0** | Procedural Poses (core) | Replace canned recovery blends with target-seeking generated poses. |

--- a/docs/SELF_PRESERVATION.md
+++ b/docs/SELF_PRESERVATION.md
@@ -1,0 +1,106 @@
+# Self-Preservation (0.4.0)
+
+The first milestone where the character *actively reacts* to a hit instead of only
+absorbing it or falling. Two behaviors:
+
+1. **Directed stumble** *(shipped)* — a staggering hit visibly **shoves the character**:
+   it lurches in the hit direction, the legs step to follow and keep it upright, and
+   the upper body reacts loosely. It ends up somewhere new, then recovers to idle.
+2. **Arm bracing** *(next)* — arms swing out to windmill for balance during a stumble,
+   and reach for the ground when a fall is committed.
+
+This is the start of the active self-preservation layer in the [scorecard](ROADMAP.md) —
+the hard, heavily-weighted part of Euphoria parity. The springs are the muscles; this
+milestone is the first piece of the *brain* telling them what to do.
+
+## Design note: directed, not emergent
+
+The first attempt drove stumbling **emergently** — wait for the centre-of-mass to drift
+into a balance band, then make a small foot reposition to "catch" it. In practice it was
+**invisible and unreliable**: most hits either never reached the band (recovered on
+their own) or blew straight past it to a ragdoll, and even when it fired, a foot
+reposition on an otherwise-rigid body didn't read as anything.
+
+The behavior was reworked to be **directed**, which is closer to how Euphoria actually
+works (a library of *triggered* physical behaviors, not pure emergent physics):
+
+- The hit **triggers** the stumble directly and reliably (not a rare emergent window).
+- The reaction is **big and legible** — it *displaces* the character, so you see it.
+- It is **art-directable** via tuning (distance, speed, step count, stiffness).
+
+The active-ragdoll springs (hardened separately — see the foot-IK orientation fix and
+the spring settle deadband) are still the body; the directed stumble drives a bold,
+reliable reaction on top of them.
+
+## Directed stumble — how it works
+
+On a staggering hit (`_start_stagger`), if the hit has a horizontal component, a stumble
+begins, driven entirely by the hit direction:
+
+**1. Knockback displacement.** The character root drifts along the hit direction at
+`stumble_push_speed`, decaying at `stumble_push_decel` (momentum absorbed). Total travel
+≈ `speed² / (2·decel)`. The springs pull the body along, so the whole character
+*displaces* — you stumble where you're shoved. (Root motion happens in
+`_physics_process`, per the locomotion rule in CLAUDE.md.)
+
+**2. Stepping feet.** Every `stumble_step_length` of travel, the **trailing foot** (the
+one furthest back along the drift) steps, up to `stumble_max_steps`. Each step, through
+`FootIKSolver.begin_stumble()`:
+- swings to a target placed *ahead of the hips* in the drift direction, **preserving the
+  foot's lateral offset** so the feet stay in their own lanes and don't cross;
+- **lifts** along a sine arc (`stumble_step_lift`) so it steps *over* the ground instead
+  of sliding across it.
+
+**3. Differential stiffness.** While stumbling, only the **lower body** (leg chains +
+pelvis) stiffens toward base (`stumble_brace_strength`) to step and stay upright. The
+**upper body is left loose** (at the stagger floor) so the torso, arms, and head react to
+the hit and the momentum. That contrast — purposeful legs, reactive upper body — is what
+reads as a live body caught off guard rather than a rigid mannequin.
+
+**4. Commit + end.** While stumbling (`_stumbling`) the tip-over→ragdoll transition is
+suspended, so the reaction plays out instead of collapsing mid-step. The stumble ends
+when the drift is spent and the last step has planted; the stagger then recovers to NORMAL
+on its own (the character stays at its new, displaced position).
+
+A strong enough hit still ragdolls (you can't catch everything); a light hit just wobbles.
+The stumble is the middle band — the visible "shoved and recovered" reaction.
+
+### New surface
+
+- `RagdollTuning` "Self-Preservation: Stumble Steps" group: `stumble_enabled`,
+  `stumble_step_length`, `stumble_step_reach_max`, `stumble_step_duration`,
+  `stumble_max_steps`, `stumble_brace_strength`, `stumble_push_speed`,
+  `stumble_push_decel`, `stumble_step_lift` (+ `stumble_step_threshold` retained for
+  future balance-driven use).
+- `FootIKSolver`: `begin_stumble(foot_rig, target, duration)` + `is_stepping()` — the foot
+  step animation (lerp + lift arc), reusing the existing stagger pin/IK/override plumbing.
+- Signal: `stumble_step_started(foot_rig, target)`.
+
+## Arm bracing — next
+
+A new `ArmIKSolver` (mirroring `FootIKSolver`) will drive the arms:
+- **Windmill** — arms swing wide to fight for balance during a stumble (the active
+  upper-body layer; right now the arms only react passively because they're loose).
+- **Reach** — when a fall is committed, the leading arm reaches toward the ground to
+  break the fall.
+
+This needs `RagdollProfile` arm-chain roles (`get_arm_chain`, mirroring the leg chains)
+and the two-bone solver factored out of `FootIKSolver` so it isn't duplicated.
+
+## State-machine integration
+
+No new states. The directed stumble lives inside `STAGGER` (`_update_directed_stumble`,
+called from `_update_stagger`) and commits across the tip-over check. Arm bracing will
+span the `STAGGER`→`RAGDOLL` transition.
+
+## Testing
+
+Following the project pattern (drive the *real* classes via `test/helpers/rig_harness.gd`):
+
+- **Directed stumble** (`test/test_stumble_step.gd`) — on a live rig, a staggering hit
+  displaces the character along the hit direction, fires steps, and recovers; disabling
+  the behavior suppresses both. The synthetic rig's emergent fall is too nonlinear to
+  assert a *physical* catch outcome, so motion *quality* is validated visually on the
+  real ybot, not asserted.
+- **Arm roles / `ArmIKSolver`** (to come) — pure-data accessor tests and a reach test,
+  as for the leg chains / foot IK.

--- a/test/test_stumble_step.gd
+++ b/test/test_stumble_step.gd
@@ -1,0 +1,81 @@
+extends GutTest
+
+# ── Directed stumble (0.4.0 Self-Preservation) ──────────────────────────────
+# A staggering hit drives a DIRECTED stumble: the character root is knocked along
+# the hit direction (visible displacement) with the feet stepping to follow, while
+# the body stiffens to stay upright. End-to-end wiring on a live physics rig
+# (res://test/helpers/rig_harness.gd) — we assert the controller actually displaces
+# the character and fires steps, and respects the enable flag. The feel/quality of
+# the motion is validated visually on the real asset, not asserted here.
+#
+# Note: in the harness the controller's character_root is the harness node, whose
+# children include the rig — so its global_position moving IS the displacement under
+# test (the ground is a sibling-ish child and moves with it, a harness quirk; on a
+# real character the root excludes the ground).
+
+const RigHarness := preload("res://test/helpers/rig_harness.gd")
+
+
+func _stumble_tuning() -> RagdollTuning:
+	var t := RagdollTuning.create_default()
+	t.foot_ik_enabled = true
+	t.foot_ik_stagger_pin = true
+	t.stumble_enabled = true
+	t.stagger_duration = 6.0          # keep the stagger open across the stumble
+	t.stagger_sway_strength = 0.0     # deterministic (sway uses a random phase)
+	return t
+
+
+# Spawns the rig and lets foot IK lazily initialize during NORMAL (the directed
+# stumble needs the foot IK solver to exist and pin). Returns in NORMAL state.
+func _spawn_ready(t: RagdollTuning):
+	var h = RigHarness.new()
+	add_child_autoqfree(h)
+	h.setup(t, null, true)
+	assert_true(await h.await_ready(40), "Kickback setup completed")
+	await wait_physics_frames(6)
+	assert_not_null(h.controller._foot_ik, "foot IK initialized during NORMAL")
+	return h
+
+
+func test_directed_stumble_displaces_and_steps():
+	var h = await _spawn_ready(_stumble_tuning())
+	var start: Vector3 = h.controller._character_root.global_position
+	watch_signals(h.controller)
+	h.controller.trigger_stagger(Vector3.FORWARD)
+	assert_true(h.controller._stumbling, "a directed stumble starts on the staggering hit")
+
+	await wait_physics_frames(45)  # let the knockback drift play out
+	var moved: Vector3 = h.controller._character_root.global_position - start
+	assert_gt(moved.length(), 0.05, "the stumble visibly displaced the character")
+	# Displacement is along the hit (forward) axis, not sideways.
+	assert_gt(absf(moved.z), absf(moved.x), "displacement is along the hit direction")
+	assert_signal_emitted(h.controller, "stumble_step_started")
+	assert_true(h.controller._stumble_step_count >= 1, "at least one step fired")
+
+
+func test_no_stumble_when_disabled():
+	var t = _stumble_tuning()
+	t.stumble_enabled = false
+	var h = await _spawn_ready(t)
+	var start: Vector3 = h.controller._character_root.global_position
+	watch_signals(h.controller)
+	h.controller.trigger_stagger(Vector3.FORWARD)
+	assert_false(h.controller._stumbling, "no directed stumble when disabled")
+
+	await wait_physics_frames(45)
+	var moved: Vector3 = h.controller._character_root.global_position - start
+	assert_lt(moved.length(), 0.02, "no knockback displacement when stumble disabled")
+	assert_signal_not_emitted(h.controller, "stumble_step_started")
+
+
+func test_stumble_ends_and_returns_to_normal():
+	var h = await _spawn_ready(_stumble_tuning())
+	h.controller.trigger_stagger(Vector3.FORWARD)
+	assert_true(h.controller._stumbling)
+	# The drift is spent within ~speed/decel seconds; the stumble flag clears and the
+	# stagger then recovers to NORMAL on its own.
+	var recovered: bool = await wait_for_signal(h.controller.stagger_finished, 8.0)
+	assert_true(recovered, "stagger recovers after the stumble")
+	assert_false(h.controller._stumbling, "stumble flag cleared")
+	assert_eq(h.controller.get_state(), ActiveRagdollController.State.NORMAL)

--- a/test/test_stumble_step.gd.uid
+++ b/test/test_stumble_step.gd.uid
@@ -1,0 +1,1 @@
+uid://k6wyf0wdkek5


### PR DESCRIPTION
## What

The first **active self-preservation reaction** for 0.4.0: a staggering hit now visibly **shoves the character** — it lurches in the hit direction, the feet step to follow, the upper body reacts, and it ends up displaced before recovering to idle.

**This consolidates and supersedes #83, #84, #85** (which describe an earlier *emergent* approach that was reworked — see below). One clean PR for the whole feature.

## The pivot it records

The first attempt drove stumbling **emergently** (wait for the centre-of-mass to drift into a balance band, then make a small foot reposition to "catch" it). In practice it was **invisible and unreliable** — most hits never reached the band or blew straight past it to a ragdoll, and a foot reposition on an otherwise-rigid body read as nothing.

Reworked to be **directed**, which is closer to how Euphoria actually works (triggered behaviors, not pure emergent physics): the hit *triggers* the reaction reliably, it's *big* (displaces the character), and it's *art-directable*. The now-unused `StumblePlanner` decision class is removed.

## How the directed stumble works

1. **Knockback displacement** — root drifts along the hit direction (`stumble_push_speed`, decaying at `stumble_push_decel`); the springs pull the body along, so the whole character *moves*.
2. **Stepping feet** — every `stumble_step_length` of travel the trailing foot steps, placed *ahead of the hips* and **kept in its own lane** (no crossing), **lifted along a sine arc** (`stumble_step_lift`) so it steps rather than slides.
3. **Differential stiffness** — only the **lower body** stiffens (`stumble_brace_strength`) to step + stay upright; the **upper body stays loose** and reacts to the momentum (purposeful legs, reactive torso/arms/head).
4. **Commit + end** — the tip-over→ragdoll transition is suspended while stumbling, so the reaction plays out; strong hits still ragdoll, light hits just wobble.

Built on the hardened active-ragdoll springs (foot-IK orientation fix + spring settle deadband, already on `main`).

## Changes

- `ActiveRagdollController` — `_update_directed_stumble` / `_do_directed_step` (hit-driven), `_apply_stumble_brace` (lower-body-only stiffening), `stumble_step_started` signal.
- `FootIKSolver` — `begin_stumble()` / `is_stepping()` with the lift arc, reusing the stagger pin/IK plumbing.
- `RagdollTuning` — "Self-Preservation: Stumble Steps" group.
- `docs/SELF_PRESERVATION.md` (directed design + the pivot), ROADMAP 0.4.0 → 🚧, CHANGELOG.

## Validation

- GUT **116/116** (`test/test_stumble_step.gd` drives the real controller + foot IK on a live rig: a hit displaces the character along the hit direction + fires steps; disabling suppresses it). Motion *quality* validated visually on the real ybot (the synthetic rig's emergent fall is too nonlinear to assert).
- Import clean. **User-validated in-editor** — reads as "shoved and stumbled," with the upper body reacting.

## Follow-up

Arm bracing (the upper-body *active* layer — windmill + reach) is next, and completes the 0.4.0 milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)