### PR TITLE
feat: RagdollProfile arm-chain roles (0.4.0 arm-bracing groundwork)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@
 ## [Unreleased]
 
 ### Added
+- **`RagdollProfile` arm-chain roles** (0.4.0 Self-Preservation groundwork) — `get_arm_chain`,
+  `get_all_arm_rigs`, `get_hand_rigs`, `is_arm_rig`, `get_arm_side`, backed by overridable
+  `left_arm_chain` / `right_arm_chain` / `hand_rigs` export fields (defaulting to the Mixamo
+  shoulder→elbow→hand convention), mirroring the existing leg-chain role API. Chains
+  filter to defined bones and return empty if incomplete, so non-Mixamo rigs work by
+  overriding the fields and missing arms degrade gracefully. `validate_against_skeleton`
+  now flags arm/hand role names that don't reference a defined rig bone. The upcoming
+  `ArmIKSolver` (windmill/reach bracing) resolves arms through these roles.
 - **Directed stumble** (0.4.0 Self-Preservation) — the first *active* survival reaction.
   A staggering hit now visibly **shoves the character**: the root drifts along the hit
   direction (`stumble_push_speed`/`stumble_push_decel`) so the reaction *displaces* it,

--- a/addons/kickback/resources/ragdoll_profile.gd
+++ b/addons/kickback/resources/ragdoll_profile.gd
@@ -32,6 +32,12 @@ extends Resource
 @export var left_leg_chain: PackedStringArray = ["UpperLeg_L", "LowerLeg_L", "Foot_L"]
 ## Ordered right leg chain, hip→knee→foot, used by foot IK.
 @export var right_leg_chain: PackedStringArray = ["UpperLeg_R", "LowerLeg_R", "Foot_R"]
+## Rig names of the hand bodies — arm IK end effectors (brace/reach contact points).
+@export var hand_rigs: PackedStringArray = ["Hand_L", "Hand_R"]
+## Ordered left arm chain, shoulder→elbow→hand, used by arm IK (brace/windmill/reach).
+@export var left_arm_chain: PackedStringArray = ["UpperArm_L", "LowerArm_L", "Hand_L"]
+## Ordered right arm chain, shoulder→elbow→hand, used by arm IK.
+@export var right_arm_chain: PackedStringArray = ["UpperArm_R", "LowerArm_R", "Hand_R"]
 
 @export_group("Special Bones")
 ## Skeleton bone name of the root body — recursion guard for bone-chain traversal.
@@ -87,6 +93,35 @@ func get_leg_side(rig_name: String) -> String:
 	if rig_name in left_leg_chain:
 		return "L"
 	if rig_name in right_leg_chain:
+		return "R"
+	return ""
+
+## Returns the ordered arm chain (shoulder→elbow→hand) for [param side] ("L" or "R"),
+## or an empty array if the chain is incomplete (arm IK needs all three links).
+func get_arm_chain(side: String) -> PackedStringArray:
+	var chain := left_arm_chain if side == "L" else right_arm_chain
+	var present := _filter_present(chain)
+	return present if present.size() == chain.size() else PackedStringArray()
+
+## Returns every arm rig name across both sides that maps to a defined bone.
+func get_all_arm_rigs() -> PackedStringArray:
+	var out := _filter_present(left_arm_chain)
+	out.append_array(_filter_present(right_arm_chain))
+	return out
+
+## Returns the hand rig names (arm IK end effectors) that map to defined bones.
+func get_hand_rigs() -> PackedStringArray:
+	return _filter_present(hand_rigs)
+
+## True if [param rig_name] belongs to either arm chain.
+func is_arm_rig(rig_name: String) -> bool:
+	return rig_name in left_arm_chain or rig_name in right_arm_chain
+
+## Returns "L"/"R" if [param rig_name] is in an arm chain, else "".
+func get_arm_side(rig_name: String) -> String:
+	if rig_name in left_arm_chain:
+		return "L"
+	if rig_name in right_arm_chain:
 		return "R"
 	return ""
 
@@ -243,6 +278,8 @@ func validate_against_skeleton(skeleton: Skeleton3D) -> PackedStringArray:
 	var list_roles := {
 		"torso_rigs": torso_rigs, "foot_rigs": foot_rigs,
 		"left_leg_chain": left_leg_chain, "right_leg_chain": right_leg_chain,
+		"hand_rigs": hand_rigs,
+		"left_arm_chain": left_arm_chain, "right_arm_chain": right_arm_chain,
 	}
 	for role_name: String in list_roles:
 		for rig: String in list_roles[role_name]:

--- a/test/test_ragdoll_profile_roles.gd
+++ b/test/test_ragdoll_profile_roles.gd
@@ -37,6 +37,43 @@ func test_leg_membership_and_side():
 	assert_eq(p.get_leg_side("Head"), "")
 
 
+# ── Arm chains (mirror the leg-chain API, for arm IK / bracing) ──────────────
+
+func test_default_arm_roles():
+	var p := RagdollProfile.create_mixamo_default()
+	assert_eq(p.get_hand_rigs(), PackedStringArray(["Hand_L", "Hand_R"]))
+	assert_eq(p.get_arm_chain("L"), PackedStringArray(["UpperArm_L", "LowerArm_L", "Hand_L"]))
+	assert_eq(p.get_arm_chain("R"), PackedStringArray(["UpperArm_R", "LowerArm_R", "Hand_R"]))
+	assert_eq(p.get_all_arm_rigs().size(), 6)
+
+
+func test_arm_membership_and_side():
+	var p := RagdollProfile.create_mixamo_default()
+	assert_true(p.is_arm_rig("Hand_L"))
+	assert_true(p.is_arm_rig("UpperArm_R"))
+	assert_false(p.is_arm_rig("Foot_L"))
+	assert_eq(p.get_arm_side("Hand_L"), "L")
+	assert_eq(p.get_arm_side("LowerArm_R"), "R")
+	assert_eq(p.get_arm_side("Head"), "")
+
+
+func test_arm_chain_filters_incomplete():
+	# Only part of the left arm exists → the chain is dropped (arm IK needs all three).
+	var p := _profile_with_rigs(["UpperArm_L", "LowerArm_L"])  # no Hand_L
+	assert_eq(p.get_arm_chain("L"), PackedStringArray())
+	assert_eq(p.get_hand_rigs(), PackedStringArray())
+
+
+func test_custom_arm_overrides():
+	var p := _profile_with_rigs(["l_clavicle", "l_uparm", "l_forearm", "l_hand"])
+	p.left_arm_chain = PackedStringArray(["l_uparm", "l_forearm", "l_hand"])
+	p.hand_rigs = PackedStringArray(["l_hand"])
+	assert_eq(p.get_arm_chain("L"), PackedStringArray(["l_uparm", "l_forearm", "l_hand"]))
+	assert_eq(p.get_hand_rigs(), PackedStringArray(["l_hand"]))
+	assert_true(p.is_arm_rig("l_forearm"))
+	assert_eq(p.get_arm_side("l_hand"), "L")
+
+
 # ── Root skeleton bone derivation (replaces hardcoded "mixamorig_Hips") ──────
 
 func test_root_skeleton_bone_derived():


### PR DESCRIPTION
## What

B1 of arm bracing (Track B of 0.4.0): the foundational, testable groundwork. Adds **arm-chain semantic roles** to `RagdollProfile`, mirroring the existing leg-chain API, so the upcoming `ArmIKSolver` resolves arms by *role* rather than hardcoded Mixamo names. **Pure data — no behavior change.**

## Changes

- Export fields `left_arm_chain` / `right_arm_chain` (shoulder→elbow→hand) and `hand_rigs`, defaulting to the Mixamo convention (`UpperArm_*`/`LowerArm_*`/`Hand_*`).
- Accessors: `get_arm_chain(side)`, `get_all_arm_rigs`, `get_hand_rigs`, `is_arm_rig`, `get_arm_side` — chains filter to defined bones and return empty if incomplete, so non-Mixamo rigs work by overriding the fields and missing arms degrade gracefully (same pattern as the legs).
- `validate_against_skeleton` flags undefined arm/hand role names.

## Validation

- GUT **116 → 120**: 4 pure tests (defaults, membership/side, incomplete-chain filtering, custom non-Mixamo override) in `test_ragdoll_profile_roles.gd`.
- Import clean.

## Next

B2 — `ArmIKSolver`, factoring the shared two-bone solve (+ `_swing`) out of `FootIKSolver`. Then B3 — windmill + reach bracing (visual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)