### PR TITLE
feat: ArmIKSolver + shared TwoBoneIK (0.4.0 arm-bracing groundwork)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@
 ## [Unreleased]
 
 ### Added
+- **`ArmIKSolver` + shared `TwoBoneIK`** (0.4.0 Self-Preservation, arm-bracing groundwork) —
+  a two-bone arm IK solver (shoulder→elbow→hand) that drives an arm to reach a world-space
+  target, blending its IK influence in and out by weight (`begin_reach`/`update_reach`/
+  `end_reach`). It resolves arms through the `RagdollProfile` arm-chain roles and mirrors
+  `FootIKSolver`'s structure (direct math in `_physics_process` → `SpringResolver` target
+  overrides). The law-of-cosines + swing-of-animation-basis math is factored out of
+  `FootIKSolver` into a shared, stateless `TwoBoneIK` util that both solvers use — no
+  duplication. The foot IK refactor is behavior-preserving (idle foot angular velocity
+  unchanged: 0.0289 → 0.0291 rad/s on the ybot at rest, within physics noise). The
+  controller wiring that triggers windmill (balance) and reach-to-ground (committed fall)
+  lands with the next, visual pass.
 - **`RagdollProfile` arm-chain roles** (0.4.0 Self-Preservation groundwork) — `get_arm_chain`,
   `get_all_arm_rigs`, `get_hand_rigs`, `is_arm_rig`, `get_arm_side`, backed by overridable
   `left_arm_chain` / `right_arm_chain` / `hand_rigs` export fields (defaulting to the Mixamo

--- a/addons/kickback/arm_ik_solver.gd
+++ b/addons/kickback/arm_ik_solver.gd
@@ -1,0 +1,229 @@
+## Two-bone arm IK solver for bracing reactions — driving the arms to windmill for
+## balance during a stumble and to reach toward the ground when a fall commits.
+## Mirrors [FootIKSolver]: direct two-bone IK (via the shared [TwoBoneIK]) computed
+## in _physics_process, feeding results to [SpringResolver.set_target_overrides].
+## Does NOT use the engine's IK nodes because PhysicsRigSync contaminates
+## SkeletonModifier3D bone pose readings.
+##
+## Owned by [ActiveRagdollController]. The controller decides WHEN each arm reaches
+## and WHERE (the directed bracing); this just animates the arm toward a world goal
+## and blends the IK in and out by weight.
+class_name ArmIKSolver
+extends RefCounted
+
+# Blend rate (per second) for ramping each arm's IK weight toward its target. A
+# local constant for now; the windmill/reach feel tuning lands with the visual pass.
+const ARM_BLEND_SPEED: float = 12.0
+
+var _spring: SpringResolver
+var _tuning: RagdollTuning
+var _character_root: Node3D
+var _skeleton: Skeleton3D
+
+var _upper_arm_len: float = 0.0
+var _lower_arm_len: float = 0.0
+var _bone_idx: Dictionary = {}  # rig_name → skeleton bone index
+
+# Resolved role rig-names (from RagdollProfile semantic roles). Defaults match the
+# Mixamo convention; initialize() overwrites them from the profile.
+var _upper_l: String = "UpperArm_L"
+var _lower_l: String = "LowerArm_L"
+var _hand_l: String = "Hand_L"
+var _upper_r: String = "UpperArm_R"
+var _lower_r: String = "LowerArm_R"
+var _hand_r: String = "Hand_R"
+
+# Per-arm reach state. _reach_active gates a target; _weight is the blended IK
+# influence (0 = pure animation, 1 = arm fully at the IK solution); _target_weight
+# is what _weight ramps toward (1 while reaching, 0 once released).
+var _reach_target_l: Vector3 = Vector3.ZERO
+var _reach_target_r: Vector3 = Vector3.ZERO
+var _reach_active_l: bool = false
+var _reach_active_r: bool = false
+var _weight_l: float = 0.0
+var _weight_r: float = 0.0
+var _target_weight_l: float = 0.0
+var _target_weight_r: float = 0.0
+
+# Hand body refs (end-effectors), cached for the fall-reach ground-contact pass.
+var _hand_body_l: RigidBody3D
+var _hand_body_r: RigidBody3D
+
+var _initialized: bool = false
+
+# Per-solve scratch buffers, reused to avoid per-frame allocations (see FootIKSolver
+# for the safety argument — each node's _physics_process runs to completion in turn).
+var _anim_cache: Dictionary = {}
+var _overrides_buf: Dictionary = {}
+
+
+func initialize(spring: SpringResolver, tuning: RagdollTuning, character_root: Node3D,
+		rig_builder: PhysicsRigBuilder, profile: RagdollProfile) -> bool:
+	_spring = spring
+	_tuning = tuning
+	_character_root = character_root
+	_skeleton = spring.get_skeleton()
+
+	if not _skeleton or not _character_root:
+		return false
+
+	# Resolve arm chains from the profile's semantic roles. A chain is empty if
+	# incomplete (arm IK needs shoulder→elbow→hand), in which case IK is unavailable.
+	var left := profile.get_arm_chain("L")
+	var right := profile.get_arm_chain("R")
+	if left.size() != 3 or right.size() != 3:
+		return false
+	_upper_l = left[0]
+	_lower_l = left[1]
+	_hand_l = left[2]
+	_upper_r = right[0]
+	_lower_r = right[1]
+	_hand_r = right[2]
+
+	# Look up bone indices for all required arm bones.
+	for rig_name: String in [_upper_l, _lower_l, _hand_l, _upper_r, _lower_r, _hand_r]:
+		var idx := spring.get_bone_idx(rig_name)
+		if idx < 0:
+			return false
+		_bone_idx[rig_name] = idx
+
+	# Compute arm segment lengths from rest poses (use left arm — symmetric skeleton).
+	var ua := _skeleton.get_bone_global_rest(_bone_idx[_upper_l])
+	var la := _skeleton.get_bone_global_rest(_bone_idx[_lower_l])
+	var ha := _skeleton.get_bone_global_rest(_bone_idx[_hand_l])
+	_upper_arm_len = ua.origin.distance_to(la.origin)
+	_lower_arm_len = la.origin.distance_to(ha.origin)
+
+	if _upper_arm_len < 0.01 or _lower_arm_len < 0.01:
+		return false
+
+	# Cache hand body refs (end-effectors) for the fall-reach contact pass.
+	var bodies := rig_builder.get_bodies()
+	_hand_body_l = bodies.get(_hand_l)
+	_hand_body_r = bodies.get(_hand_r)
+
+	_initialized = true
+	return true
+
+
+func is_initialized() -> bool:
+	return _initialized
+
+
+## True while either arm's IK has any influence (mid-blend or fully reaching).
+func is_active() -> bool:
+	return _weight_l > 0.001 or _weight_r > 0.001
+
+
+## True while either arm has an active reach target (regardless of blend progress).
+func is_reaching() -> bool:
+	return _reach_active_l or _reach_active_r
+
+
+# ── Reach control (driven by the controller) ───────────────────────────────
+
+## Starts driving the arm on [param side] ("L"/"R") toward the world-space
+## [param target]. The IK weight blends in over the next frames. Call
+## [method update_reach] each frame to move a windmilling/tracking target.
+func begin_reach(side: String, target: Vector3) -> void:
+	if side == "L":
+		_reach_target_l = target
+		_reach_active_l = true
+		_target_weight_l = 1.0
+	elif side == "R":
+		_reach_target_r = target
+		_reach_active_r = true
+		_target_weight_r = 1.0
+
+
+## Moves an already-active reach target without changing its blend (use to animate a
+## windmill arc or to track a moving ground contact). No-op if the arm isn't reaching.
+func update_reach(side: String, target: Vector3) -> void:
+	if side == "L" and _reach_active_l:
+		_reach_target_l = target
+	elif side == "R" and _reach_active_r:
+		_reach_target_r = target
+
+
+## Releases the arm on [param side]; its IK weight blends back out to the animation
+## pose over the next frames.
+func end_reach(side: String) -> void:
+	if side == "L":
+		_reach_active_l = false
+		_target_weight_l = 0.0
+	elif side == "R":
+		_reach_active_r = false
+		_target_weight_r = 0.0
+
+
+# ── Solve ──────────────────────────────────────────────────────────────────
+
+func process(delta: float) -> void:
+	if not _initialized:
+		return
+	# Nothing to do once both arms are released and fully blended out.
+	if not is_reaching() and not is_active():
+		return
+	_solve(delta)
+
+
+func _solve(delta: float) -> void:
+	var sg := _skeleton.global_transform
+	_anim_cache.clear()
+	var overrides := _overrides_buf
+	overrides.clear()
+
+	# Ramp each arm's weight toward its target (frame-rate-independent blend).
+	var blend := 1.0 - exp(-ARM_BLEND_SPEED * delta)
+	_weight_l = lerpf(_weight_l, _target_weight_l, blend)
+	_weight_r = lerpf(_weight_r, _target_weight_r, blend)
+
+	if _weight_l > 0.001:
+		_solve_arm(overrides, _upper_l, _lower_l, _hand_l, _reach_target_l, _weight_l, sg)
+	if _weight_r > 0.001:
+		_solve_arm(overrides, _upper_r, _lower_r, _hand_r, _reach_target_r, _weight_r, sg)
+
+	_spring.set_target_overrides(overrides)
+
+
+## Solves one arm toward [param target] and writes weight-blended overrides for its
+## three bones. The hand keeps its animation orientation (no slope concept for a
+## hand) and sits at the target; the shoulder/elbow swing to follow.
+func _solve_arm(overrides: Dictionary, upper_name: String, lower_name: String,
+		hand_name: String, target: Vector3, weight: float, sg: Transform3D) -> void:
+	var upper_anim := _anim_global(_bone_idx[upper_name], sg)
+	var lower_anim := _anim_global(_bone_idx[lower_name], sg)
+	var hand_anim := _anim_global(_bone_idx[hand_name], sg)
+
+	var ik := TwoBoneIK.solve(_upper_arm_len, _lower_arm_len, upper_anim.origin,
+		target, lower_anim.origin, upper_anim, lower_anim, hand_anim,
+		-_character_root.global_basis.z)
+	if ik.is_empty():
+		# Target unreachable — leave this arm at its animation pose (no override).
+		return
+
+	var hand_ik := Transform3D(hand_anim.basis, target)
+	overrides[upper_name] = upper_anim.interpolate_with(ik["upper"], weight)
+	overrides[lower_name] = lower_anim.interpolate_with(ik["lower"], weight)
+	overrides[hand_name] = hand_anim.interpolate_with(hand_ik, weight)
+
+
+## World-space animation global for a bone index, memoized per solve (see
+## FootIKSolver._anim_global). Caller clears _anim_cache at the start of each solve.
+func _anim_global(bone_idx: int, sg: Transform3D) -> Transform3D:
+	if _anim_cache.has(bone_idx):
+		return _anim_cache[bone_idx]
+	var g := sg * _spring.get_animation_bone_global(bone_idx)
+	_anim_cache[bone_idx] = g
+	return g
+
+
+# ── Reset (RAGDOLL/GETTING_UP/PERSISTENT) ──────────────────────────────────
+
+func reset() -> void:
+	_reach_active_l = false
+	_reach_active_r = false
+	_target_weight_l = 0.0
+	_target_weight_r = 0.0
+	_weight_l = 0.0
+	_weight_r = 0.0

--- a/addons/kickback/arm_ik_solver.gd.uid
+++ b/addons/kickback/arm_ik_solver.gd.uid
@@ -1,0 +1,1 @@
+uid://bh4re5r0ep2aj

--- a/addons/kickback/foot_ik_solver.gd
+++ b/addons/kickback/foot_ik_solver.gd
@@ -401,84 +401,28 @@ func _anim_global(bone_idx: int, sg: Transform3D) -> Transform3D:
 	return g
 
 
-# ── Two-bone IK solver (law of cosines) ───────────────────────────────────
+# ── Two-bone IK solver (shared TwoBoneIK) ──────────────────────────────────
 
-## Solves the leg as a correction OF the animation pose: it computes where the
-## knee/foot should go (positions, via law of cosines) and then expresses each
-## segment's orientation as a SWING of that segment's animation basis onto the new
-## bone direction. This is convention-agnostic — when the IK direction equals the
-## animation direction (no adjustment needed), the swing is identity and the target
-## equals the animation pose, so there is no spurious rotation error for the spring
-## to chase. (Building bases from scratch with an assumed local-axis convention
-## produced ~130° steady orientation errors against Mixamo bones → idle leg buzz.)
+## Solves the leg as a correction OF the animation pose via the shared [TwoBoneIK]
+## (positions by law of cosines, orientations as a swing of each segment's animation
+## basis — see TwoBoneIK for why). This wrapper adds the leg-specific bits: the
+## pelvis shift on the position chain and the foot's slope correction.
 ## [param upper_anim]/[param lower_anim]/[param foot_anim] are world-space animation
 ## globals; [param ps] is the pelvis shift applied to the position chain.
 func _solve_two_bone_ik(upper_anim: Transform3D, lower_anim: Transform3D,
 		foot_anim: Transform3D, foot_target: Vector3, ground_normal: Vector3,
 		ps: Vector3) -> Dictionary:
-	var hip_pos := upper_anim.origin + ps
-	var cv := foot_target - hip_pos
-	var cl := cv.length()
-	var mx := _upper_leg_len + _lower_leg_len - 0.01
-	var mn := absf(_upper_leg_len - _lower_leg_len) + 0.01
-	if cl < mn or cl > mx + 0.1:
+	var ik := TwoBoneIK.solve(_upper_leg_len, _lower_leg_len, upper_anim.origin + ps,
+		foot_target, lower_anim.origin + ps, upper_anim, lower_anim, foot_anim,
+		-_character_root.global_basis.z)
+	if ik.is_empty():
 		return {}
-	cl = clampf(cl, mn, mx)
-
-	# Law of cosines: hip angle
-	var ch := (_upper_leg_len * _upper_leg_len + cl * cl - _lower_leg_len * _lower_leg_len) / (2.0 * _upper_leg_len * cl)
-	ch = clampf(ch, -1.0, 1.0)
-	var ho := acos(ch)
-
-	# Bend plane from the animation knee direction (keeps the knee bending the way
-	# the animation already does).
-	var knee_hint := lower_anim.origin + ps
-	var cd := cv.normalized()
-	var kf := (knee_hint - hip_pos).normalized()
-	var side := cd.cross(kf).normalized()
-	if side.length_squared() < 0.001:
-		side = cd.cross(-_character_root.global_basis.z).normalized()
-	if side.length_squared() < 0.001:
-		side = cd.cross(Vector3.RIGHT).normalized()
-	var bd := side.cross(cd).normalized()
-
-	# Upper/lower leg directions and the knee position between them.
-	var ud := (cd * cos(ho) + bd * sin(ho)).normalized()
-	var kp := hip_pos + ud * _upper_leg_len
-	var ld := (foot_target - kp).normalized()
-
-	# Orientation as a swing of the animation basis onto the new bone direction.
-	var anim_upper_dir := (lower_anim.origin - upper_anim.origin).normalized()
-	var anim_lower_dir := (foot_anim.origin - lower_anim.origin).normalized()
-	var ux := Transform3D(Basis(_swing(anim_upper_dir, ud)) * upper_anim.basis, hip_pos)
-	var lx := Transform3D(Basis(_swing(anim_lower_dir, ld)) * lower_anim.basis, kp)
 
 	# Foot rotation: apply slope delta to the animation pose.
 	# On flat ground (normal=UP) this is identity — no correction.
 	var slope_correction := Quaternion(Vector3.UP, ground_normal.normalized())
-	var fb := Basis(slope_correction) * foot_anim.basis
-	var fx := Transform3D(fb, foot_target)
-
-	return {"upper": ux, "lower": lx, "foot": fx}
-
-
-## Shortest-arc rotation from [param from] to [param to], hardened against the zero
-## and antiparallel degeneracies that the bare Quaternion(from, to) constructor
-## asserts on.
-func _swing(from: Vector3, to: Vector3) -> Quaternion:
-	if from.length_squared() < 0.0001 or to.length_squared() < 0.0001:
-		return Quaternion.IDENTITY
-	var f := from.normalized()
-	var t := to.normalized()
-	var d := f.dot(t)
-	if d > 0.9999:
-		return Quaternion.IDENTITY
-	if d < -0.9999:
-		var axis := f.cross(Vector3.UP)
-		if axis.length_squared() < 0.0001:
-			axis = f.cross(Vector3.RIGHT)
-		return Quaternion(axis.normalized(), PI)
-	return Quaternion(f, t)
+	ik["foot"] = Transform3D(Basis(slope_correction) * foot_anim.basis, foot_target)
+	return ik
 
 
 # ── Leg blend helper ───────────────────────────────────────────────────────

--- a/addons/kickback/two_bone_ik.gd
+++ b/addons/kickback/two_bone_ik.gd
@@ -1,0 +1,96 @@
+## Shared two-bone IK math, used by both [FootIKSolver] (leg: hip→knee→foot) and
+## [ArmIKSolver] (arm: shoulder→elbow→hand). Pure, stateless static functions —
+## no scene, no spring, no per-instance state.
+##
+## Solves the chain as a CORRECTION OF the animation pose: the mid-joint position
+## and the two segment directions come from the law of cosines, but each segment's
+## ORIENTATION is expressed as a SWING of that segment's animation basis onto its
+## new direction. This is convention-agnostic — when the IK direction equals the
+## animation direction (no adjustment needed) the swing is identity and the target
+## equals the animation pose, so there is no spurious rotation error for the spring
+## to chase. (Building bases from scratch with an assumed local-axis convention
+## produced ~130° steady orientation errors against Mixamo bones → idle leg buzz;
+## see the foot-IK orientation fix.)
+class_name TwoBoneIK
+extends RefCounted
+
+
+## Solves a two-bone chain anchored at [param root_pos] reaching toward
+## [param target]. Returns an empty dictionary if the target is unreachable
+## (degenerate length), else
+## [code]{"upper": Transform3D, "lower": Transform3D, "knee": Vector3}[/code]:
+## [code]upper[/code]/[code]lower[/code] are the world-space segment transforms
+## (swung animation basis at the solved positions); [code]knee[/code] is the solved
+## mid-joint position. The caller owns the end-effector (foot/hand) transform — it
+## sits at [param target] with a caller-chosen orientation (e.g. slope-corrected
+## for a planted foot, animation-preserving for a reaching hand).
+##
+## [param upper_len]/[param lower_len] are the two segment lengths.
+## [param root_pos] is the chain anchor (hip/shoulder), already including any shift.
+## [param target] is the end-effector goal in world space.
+## [param knee_hint] is the animation mid-joint position (same shift as root_pos);
+## it defines which way the joint bends.
+## [param upper_anim]/[param lower_anim]/[param end_anim] are the world-space
+## animation globals of the two segments and the end bone; their bases are swung for
+## the output and their origins give the animation segment directions.
+## [param fallback_axis] seeds the bend plane when [param target] and
+## [param knee_hint] are colinear (the cross product degenerates).
+static func solve(upper_len: float, lower_len: float, root_pos: Vector3,
+		target: Vector3, knee_hint: Vector3, upper_anim: Transform3D,
+		lower_anim: Transform3D, end_anim: Transform3D,
+		fallback_axis: Vector3) -> Dictionary:
+	var cv := target - root_pos
+	var cl := cv.length()
+	var mx := upper_len + lower_len - 0.01
+	var mn := absf(upper_len - lower_len) + 0.01
+	if cl < mn or cl > mx + 0.1:
+		return {}
+	cl = clampf(cl, mn, mx)
+
+	# Law of cosines: angle at the root between the chain line and the upper segment.
+	var ch := (upper_len * upper_len + cl * cl - lower_len * lower_len) / (2.0 * upper_len * cl)
+	ch = clampf(ch, -1.0, 1.0)
+	var ho := acos(ch)
+
+	# Bend plane from the animation mid-joint direction (keeps the joint bending the
+	# way the animation already does).
+	var cd := cv.normalized()
+	var kf := (knee_hint - root_pos).normalized()
+	var side := cd.cross(kf).normalized()
+	if side.length_squared() < 0.001:
+		side = cd.cross(fallback_axis).normalized()
+	if side.length_squared() < 0.001:
+		side = cd.cross(Vector3.RIGHT).normalized()
+	var bd := side.cross(cd).normalized()
+
+	# Upper/lower segment directions and the mid-joint between them.
+	var ud := (cd * cos(ho) + bd * sin(ho)).normalized()
+	var kp := root_pos + ud * upper_len
+	var ld := (target - kp).normalized()
+
+	# Orientation as a swing of each animation basis onto its new bone direction.
+	var anim_upper_dir := (lower_anim.origin - upper_anim.origin).normalized()
+	var anim_lower_dir := (end_anim.origin - lower_anim.origin).normalized()
+	var ux := Transform3D(Basis(swing(anim_upper_dir, ud)) * upper_anim.basis, root_pos)
+	var lx := Transform3D(Basis(swing(anim_lower_dir, ld)) * lower_anim.basis, kp)
+
+	return {"upper": ux, "lower": lx, "knee": kp}
+
+
+## Shortest-arc rotation from [param from] to [param to], hardened against the zero
+## and antiparallel degeneracies that the bare [code]Quaternion(from, to)[/code]
+## constructor asserts on.
+static func swing(from: Vector3, to: Vector3) -> Quaternion:
+	if from.length_squared() < 0.0001 or to.length_squared() < 0.0001:
+		return Quaternion.IDENTITY
+	var f := from.normalized()
+	var t := to.normalized()
+	var d := f.dot(t)
+	if d > 0.9999:
+		return Quaternion.IDENTITY
+	if d < -0.9999:
+		var axis := f.cross(Vector3.UP)
+		if axis.length_squared() < 0.0001:
+			axis = f.cross(Vector3.RIGHT)
+		return Quaternion(axis.normalized(), PI)
+	return Quaternion(f, t)

--- a/addons/kickback/two_bone_ik.gd.uid
+++ b/addons/kickback/two_bone_ik.gd.uid
@@ -1,0 +1,1 @@
+uid://cdjn0n4wcd8ht

--- a/docs/SELF_PRESERVATION.md
+++ b/docs/SELF_PRESERVATION.md
@@ -78,14 +78,23 @@ The stumble is the middle band — the visible "shoved and recovered" reaction.
 
 ## Arm bracing — next
 
-A new `ArmIKSolver` (mirroring `FootIKSolver`) will drive the arms:
-- **Windmill** — arms swing wide to fight for balance during a stumble (the active
-  upper-body layer; right now the arms only react passively because they're loose).
+The arms get an active layer (right now they only react passively because they're loose):
+- **Windmill** — arms swing wide to fight for balance during a stumble.
 - **Reach** — when a fall is committed, the leading arm reaches toward the ground to
   break the fall.
 
-This needs `RagdollProfile` arm-chain roles (`get_arm_chain`, mirroring the leg chains)
-and the two-bone solver factored out of `FootIKSolver` so it isn't duplicated.
+**Groundwork done.** `RagdollProfile` arm-chain roles (`get_arm_chain`, mirroring the leg
+chains) and the `ArmIKSolver` exist. The two-bone math (law of cosines + swing-of-animation
+basis) is factored out of `FootIKSolver` into a shared, stateless `TwoBoneIK` util that both
+solvers use, so there's no duplication; the foot IK refactor is behavior-preserving (idle
+foot buzz unchanged within physics noise). `ArmIKSolver` mirrors `FootIKSolver`: it drives an
+arm to reach a world-space target and blends its IK weight in/out (`begin_reach`/
+`update_reach`/`end_reach`), resolving arms through the arm-chain roles.
+
+**Still to come (the visual pass):** wiring the controller to *trigger* the windmill arc
+during the directed stumble and the ground reach on a committed fall, plus the feel tuning —
+and the override-channel coordination so arm IK and foot IK can write the spring at the same
+time (each currently replaces the whole override set, which is fine while only one runs).
 
 ## State-machine integration
 

--- a/test/test_arm_ik.gd
+++ b/test/test_arm_ik.gd
@@ -1,0 +1,136 @@
+extends GutTest
+
+
+# ── ArmIKSolver tests ───────────────────────────────────────────────────────
+# Two layers, mirroring test_foot_ik.gd:
+#   1. Lifecycle tests that exercise the real solver with no scene.
+#   2. Runtime tests that drive the REAL ArmIKSolver on a live rig built by
+#      res://test/helpers/rig_harness.gd. Foot IK is disabled so the arm solver
+#      owns the spring's override channel (co-running both is the B3 wiring step).
+#
+# The solver reads ANIMATION globals (static at idle in the harness), so the reach
+# blend is driven deterministically by calling process() in a loop and asserting on
+# the override buffer — no coupling to physics-tick ordering.
+
+const RigHarness := preload("res://test/helpers/rig_harness.gd")
+
+
+func _spawn(extra_frames: int = 10):
+	var t := RagdollTuning.create_default()
+	t.foot_ik_enabled = false  # free the override channel for the arm solver
+	var h = RigHarness.new()
+	add_child_autoqfree(h)
+	h.setup(t, null, true)
+	var ok: bool = await h.await_ready(40)
+	assert_true(ok, "Kickback setup completed within frame budget")
+	await wait_physics_frames(extra_frames)
+	return h
+
+
+# Builds + initializes the real ArmIKSolver against the harness rig.
+func _make_solver(h) -> ArmIKSolver:
+	var solver := ArmIKSolver.new()
+	var ok := solver.initialize(h.spring, h.tuning, h, h.rig_builder, h.profile)
+	assert_true(ok, "ArmIKSolver initialized against the rig")
+	return solver
+
+
+# World-space animation origin of a rig bone (the solver's reach anchor space).
+func _bone_world(h, rig_name: String) -> Vector3:
+	var idx: int = h.spring.get_bone_idx(rig_name)
+	return (h.skeleton.global_transform * h.spring.get_animation_bone_global(idx)).origin
+
+
+# Runs the solver's solve loop for [param frames] fixed 60 Hz steps.
+func _pump(solver: ArmIKSolver, frames: int) -> void:
+	for i in frames:
+		solver.process(1.0 / 60.0)
+
+
+# ── Lifecycle (real class, no scene) ───────────────────────────────────────
+
+func test_solver_creation():
+	var solver := ArmIKSolver.new()
+	assert_not_null(solver)
+	assert_false(solver.is_initialized())
+	assert_false(solver.is_active())
+	assert_false(solver.is_reaching())
+
+
+func test_uninitialized_calls_are_safe():
+	var solver := ArmIKSolver.new()
+	solver.process(0.016)
+	solver.begin_reach("L", Vector3(1, 1, 1))
+	solver.update_reach("L", Vector3(2, 2, 2))
+	solver.end_reach("L")
+	solver.reset()
+	# begin_reach sets state flags even before init, but process() is a no-op, so the
+	# solver never becomes active without an initialized rig.
+	assert_false(solver.is_active())
+
+
+func test_reset_clears_reach_state():
+	var solver := ArmIKSolver.new()
+	solver.begin_reach("L", Vector3(1, 0, 0))
+	solver.begin_reach("R", Vector3(-1, 0, 0))
+	assert_true(solver.is_reaching())
+	solver.reset()
+	assert_false(solver.is_reaching())
+	assert_false(solver.is_active())
+
+
+# ── Real ArmIKSolver on a live rig ─────────────────────────────────────────
+
+func test_initializes_and_reads_arm_lengths():
+	var h = await _spawn()
+	var solver = _make_solver(h)
+	assert_true(solver.is_initialized())
+	# Lengths derived from the synthetic skeleton's rest poses (0.28 m + 0.25 m).
+	assert_almost_eq(solver._upper_arm_len, 0.28, 0.02, "upper arm length read from rest")
+	assert_almost_eq(solver._lower_arm_len, 0.25, 0.02, "lower arm length read from rest")
+
+
+func test_reach_drives_hand_to_target():
+	var h = await _spawn()
+	var solver = _make_solver(h)
+	# A target within reach of the left shoulder (total arm reach ≈ 0.53 m).
+	var shoulder := _bone_world(h, "UpperArm_L")
+	var target := shoulder + Vector3(0.25, -0.15, 0.15)
+	solver.begin_reach("L", target)
+	_pump(solver, 50)
+
+	assert_gt(solver._weight_l, 0.9, "left arm IK weight blended in")
+	assert_true(solver._overrides_buf.has("Hand_L"), "left hand override written")
+	var hand_t: Transform3D = solver._overrides_buf["Hand_L"]
+	assert_almost_eq(hand_t.origin.distance_to(target), 0.0, 0.02,
+		"left hand reaches the target")
+	assert_true(solver._overrides_buf.has("UpperArm_L") and solver._overrides_buf.has("LowerArm_L"),
+		"shoulder and elbow overrides written")
+	# The other arm is untouched.
+	assert_false(solver._overrides_buf.has("Hand_R"), "right arm not driven")
+	assert_true(solver.is_active())
+
+
+func test_unreachable_target_leaves_arm_at_anim():
+	var h = await _spawn()
+	var solver = _make_solver(h)
+	var shoulder := _bone_world(h, "UpperArm_R")
+	# Far beyond arm reach — the solve degenerates, so no override is written.
+	solver.begin_reach("R", shoulder + Vector3(5.0, 0, 0))
+	_pump(solver, 30)
+	assert_gt(solver._weight_r, 0.9, "weight still ramps even when unreachable")
+	assert_false(solver._overrides_buf.has("Hand_R"),
+		"unreachable target writes no override (arm stays at animation pose)")
+
+
+func test_end_reach_blends_weight_out():
+	var h = await _spawn()
+	var solver = _make_solver(h)
+	var shoulder := _bone_world(h, "UpperArm_L")
+	solver.begin_reach("L", shoulder + Vector3(0.2, -0.1, 0.1))
+	_pump(solver, 40)
+	assert_gt(solver._weight_l, 0.9, "weight blended in")
+	solver.end_reach("L")
+	assert_false(solver.is_reaching(), "reach released")
+	_pump(solver, 40)
+	assert_lt(solver._weight_l, 0.05, "weight blended back out after release")

--- a/test/test_arm_ik.gd.uid
+++ b/test/test_arm_ik.gd.uid
@@ -1,0 +1,1 @@
+uid://5cy6buwiw6kn

--- a/test/test_two_bone_ik.gd
+++ b/test/test_two_bone_ik.gd
@@ -1,0 +1,114 @@
+extends GutTest
+
+
+# ── TwoBoneIK tests ─────────────────────────────────────────────────────────
+# Pure, stateless math — the shared two-bone solver used by both FootIKSolver and
+# ArmIKSolver. Tests assert geometric invariants (segment lengths, anchor
+# positions, reachability) that hold regardless of bone convention, plus the
+# hardened swing() degeneracy handling.
+
+
+# ── swing(): shortest-arc rotation, hardened ───────────────────────────────
+
+func test_swing_parallel_is_identity():
+	var q := TwoBoneIK.swing(Vector3(1, 0, 0), Vector3(2, 0, 0))
+	assert_almost_eq(q.x, 0.0, 0.0001)
+	assert_almost_eq(q.y, 0.0, 0.0001)
+	assert_almost_eq(q.z, 0.0, 0.0001)
+	assert_almost_eq(absf(q.w), 1.0, 0.0001, "parallel vectors → identity rotation")
+
+
+func test_swing_zero_input_is_identity():
+	assert_eq(TwoBoneIK.swing(Vector3.ZERO, Vector3(1, 0, 0)), Quaternion.IDENTITY)
+	assert_eq(TwoBoneIK.swing(Vector3(1, 0, 0), Vector3.ZERO), Quaternion.IDENTITY)
+
+
+func test_swing_rotates_from_onto_to():
+	var q := TwoBoneIK.swing(Vector3(1, 0, 0), Vector3(0, 1, 0))
+	var rotated := (q * Vector3(1, 0, 0)).normalized()
+	assert_almost_eq(rotated.x, 0.0, 0.0001)
+	assert_almost_eq(rotated.y, 1.0, 0.0001)
+	assert_almost_eq(rotated.z, 0.0, 0.0001)
+
+
+func test_swing_antiparallel_is_180():
+	# Antiparallel is the degeneracy the bare Quaternion(from, to) constructor
+	# asserts on; swing() must return a valid 180° rotation onto the target.
+	var q := TwoBoneIK.swing(Vector3(1, 0, 0), Vector3(-1, 0, 0))
+	var rotated := (q * Vector3(1, 0, 0)).normalized()
+	assert_almost_eq(rotated.x, -1.0, 0.001, "antiparallel → flips the vector")
+	assert_almost_eq(q.get_axis().length(), 1.0, 0.001, "valid (non-NaN) rotation axis")
+
+
+# ── solve(): two-bone IK invariants ────────────────────────────────────────
+
+# A bent, reachable target. Equal-length segments anchored at (0,1,0), animation
+# pose straight down, target pulled forward so the joint must bend.
+func _bent_solve() -> Dictionary:
+	var upper_anim := Transform3D(Basis(), Vector3(0, 1.0, 0))
+	var lower_anim := Transform3D(Basis(), Vector3(0, 0.6, 0))
+	var end_anim := Transform3D(Basis(), Vector3(0, 0.2, 0))
+	var target := Vector3(0.2, 0.3, 0.0)
+	return TwoBoneIK.solve(0.4, 0.4, upper_anim.origin, target, lower_anim.origin,
+		upper_anim, lower_anim, end_anim, Vector3(0, 0, -1))
+
+
+func test_solve_reachable_returns_chain():
+	var ik := _bent_solve()
+	assert_false(ik.is_empty(), "reachable target solves")
+	assert_true(ik.has("upper") and ik.has("lower") and ik.has("knee"))
+
+
+func test_solve_anchors_upper_at_root():
+	var ik := _bent_solve()
+	var upper: Transform3D = ik["upper"]
+	assert_almost_eq(upper.origin.distance_to(Vector3(0, 1.0, 0)), 0.0, 0.0001,
+		"upper segment is anchored at the root position")
+
+
+func test_solve_segment_lengths_preserved():
+	var ik := _bent_solve()
+	var knee: Vector3 = ik["knee"]
+	var lower: Transform3D = ik["lower"]
+	# Knee sits one upper-length from the root and one lower-length from the target.
+	assert_almost_eq(knee.distance_to(Vector3(0, 1.0, 0)), 0.4, 0.001,
+		"root→knee equals the upper segment length")
+	assert_almost_eq(knee.distance_to(Vector3(0.2, 0.3, 0.0)), 0.4, 0.001,
+		"knee→target equals the lower segment length")
+	# The lower segment transform is anchored at the knee.
+	assert_almost_eq(lower.origin.distance_to(knee), 0.0, 0.0001,
+		"lower segment is anchored at the knee")
+
+
+func test_solve_unreachable_returns_empty():
+	var upper_anim := Transform3D(Basis(), Vector3(0, 1.0, 0))
+	var lower_anim := Transform3D(Basis(), Vector3(0, 0.6, 0))
+	var end_anim := Transform3D(Basis(), Vector3(0, 0.2, 0))
+	# Target far beyond the 0.8 m total reach.
+	var ik := TwoBoneIK.solve(0.4, 0.4, upper_anim.origin, Vector3(5, 1, 0),
+		lower_anim.origin, upper_anim, lower_anim, end_anim, Vector3(0, 0, -1))
+	assert_true(ik.is_empty(), "target beyond reach returns empty")
+
+
+# When the target sits exactly at the animation's own end position, the IK should
+# reproduce the animation pose: both swings are identity, so each segment keeps its
+# animation basis. This is what avoids spurious rotation error for the spring.
+func test_solve_no_adjustment_keeps_anim_basis():
+	# Right-angle bent pose: upper along +X, lower along -Y (each 0.4 m).
+	var rot := Basis(Vector3(1, 0, 0), deg_to_rad(30.0))  # arbitrary non-identity basis
+	var upper_anim := Transform3D(rot, Vector3(0.0, 1.0, 0))
+	var lower_anim := Transform3D(rot, Vector3(0.4, 1.0, 0))  # knee
+	var end_anim := Transform3D(rot, Vector3(0.4, 0.6, 0))   # end effector
+	# Target == the animation's own end position → no adjustment needed.
+	var ik := TwoBoneIK.solve(0.4, 0.4, upper_anim.origin, end_anim.origin,
+		lower_anim.origin, upper_anim, lower_anim, end_anim, Vector3(0, 0, -1))
+	assert_false(ik.is_empty())
+	var upper: Transform3D = ik["upper"]
+	var lower: Transform3D = ik["lower"]
+	# Bases unchanged (swing ≈ identity) → no rotation error for the spring to chase.
+	assert_true(upper.basis.is_equal_approx(rot),
+		"upper segment stays at its animation basis when no adjustment is needed")
+	assert_true(lower.basis.is_equal_approx(rot),
+		"lower segment stays at its animation basis when no adjustment is needed")
+	# And the solved knee lands on the animation knee.
+	assert_almost_eq((ik["knee"] as Vector3).distance_to(Vector3(0.4, 1.0, 0)), 0.0, 0.001)

--- a/test/test_two_bone_ik.gd.uid
+++ b/test/test_two_bone_ik.gd.uid
@@ -1,0 +1,1 @@
+uid://c32oh1xw4um4s


### PR DESCRIPTION
## What

Track B step 2 of 0.4.0 Self-Preservation (arm bracing). Builds the arm IK layer and removes the two-bone IK duplication it would otherwise introduce. Testable, no visual change to the live character yet — the triggering/feel pass is next.

## Changes

- **Shared `TwoBoneIK` util** — factor the law-of-cosines + swing-of-animation-basis math out of `FootIKSolver` into a stateless static util. `FootIKSolver` delegates to it, keeping only the leg-specific bits (pelvis shift, foot slope correction).
- **`ArmIKSolver`** — mirrors `FootIKSolver`: resolves arms via the `RagdollProfile` arm-chain roles (merged in #90), drives a shoulder→elbow→hand chain to a world target, and blends IK weight in/out by reach state (`begin_reach`/`update_reach`/`end_reach`). An unreachable target leaves the arm at its animation pose.
- **Tests** — pure `TwoBoneIK` math (swing degeneracies, segment-length invariants, identity-when-no-adjustment) + the real `ArmIKSolver` on a live harness rig (reach drives the hand to target, unreachable no-ops, weight blends out on release).

## Behavior-preserving refactor — verified

The refactor touches the feel-validated foot IK, so I A/B-measured idle foot angular velocity on the **real ybot** at rest with the same harness:

| | avg foot angular velocity |
|---|---|
| `main` (inline math) | 0.0289 rad/s |
| this branch (`TwoBoneIK`) | 0.0291 rad/s |

0.0002 difference = physics nondeterminism noise. Foot planting/pelvis tests still green.

## Tests

GUT **120 → 136** (9 `TwoBoneIK` + 7 `ArmIKSolver`), full suite green.

## Next

Controller wiring to *trigger* the windmill (balance) and reach-to-ground (committed fall), the feel tuning, and override-channel coordination so arm + foot IK can write the spring simultaneously (each currently replaces the whole override set — fine while only one runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)