### PR TITLE
feat: arm bracing — windmill + reach-for-ground (0.4.0 B3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@
 ## [Unreleased]
 
 ### Added
+- **Arm bracing** (0.4.0 Self-Preservation) — the upper-body active layer, so the whole
+  reaction reads together. During a directed stumble the arms **windmill** for balance:
+  each hand sweeps a wide vertical circle out to its own side (the two arms in opposite
+  phase), the arc coupled to the stumble's momentum and aligned to the fall direction so
+  it reads as a reaction to *this* hit rather than a canned loop, layered at partial weight
+  over the loose flail. When a hit commits to a **fall**, the leading arm **reaches for the
+  ground** to break it: a brief braced window keeps that arm's springs alive and drives its
+  hand toward the ground (anchored to the physical arm, since the body has left its
+  animation pose) while the rest goes limp, then releases into the full ragdoll. Gated to
+  forward/side falls (a backward fall can't be broken by a hands-forward plant). New
+  `RagdollTuning` "Self-Preservation: Arm Bracing" group (`arm_brace_enabled`,
+  `arm_brace_weight`, `arm_windmill_radius`/`lateral`/`height`/`speed`,
+  `arm_brace_blend_speed`, `arm_fall_reach_enabled`/`duration`/`strength`/`distance`/
+  `weight`/`min_facing`); the F3 debug HUD draws the fall-reach target; the Tuning Lab
+  gains live sliders for the stumble + arm-bracing knobs.
 - **`ArmIKSolver` + shared `TwoBoneIK`** (0.4.0 Self-Preservation, arm-bracing groundwork) —
   a two-bone arm IK solver (shoulder→elbow→hand) that drives an arm to reach a world-space
   target, blending its IK influence in and out by weight (`begin_reach`/`update_reach`/

--- a/addons/kickback/active_ragdoll_controller.gd
+++ b/addons/kickback/active_ragdoll_controller.gd
@@ -506,13 +506,19 @@ func _update_arm_windmill(delta: float) -> void:
 	if not _arm_ik or not _tuning.arm_brace_enabled:
 		return
 	_windmill_phase += _tuning.arm_windmill_speed * delta
-	_drive_windmill_arm("L", _arm_shoulder_l, _windmill_phase)
-	_drive_windmill_arm("R", _arm_shoulder_r, _windmill_phase + PI)
+	# Couple the windmill to the body's momentum: full size right after the hit, winding
+	# down as the drift is spent, so the arms settle WITH the body rather than spinning on
+	# after it has stopped (a constant-size circle reads as a detached, canned layer).
+	var push: float = maxf(_tuning.stumble_push_speed, 0.01)
+	var intensity := clampf(_stumble_drift / push, 0.0, 1.0)
+	_drive_windmill_arm("L", _arm_shoulder_l, _windmill_phase, intensity)
+	_drive_windmill_arm("R", _arm_shoulder_r, _windmill_phase + PI, intensity)
 
 
 ## Points one arm's windmill target for this frame. [param shoulder_rig] is the chain's
-## shoulder body (the circle anchor); [param phase] is its position around the sweep.
-func _drive_windmill_arm(side: String, shoulder_rig: String, phase: float) -> void:
+## shoulder body (the circle anchor); [param phase] is its position around the sweep;
+## [param intensity] (0..1, the remaining stumble momentum) scales the arc and the lean.
+func _drive_windmill_arm(side: String, shoulder_rig: String, phase: float, intensity: float) -> void:
 	if shoulder_rig == "":
 		return
 	var bodies := _rig_builder.get_bodies()
@@ -531,12 +537,23 @@ func _drive_windmill_arm(side: String, shoulder_rig: String, phase: float) -> vo
 		outward = _character_root.global_basis.x * (1.0 if side == "L" else -1.0)
 	outward = outward.normalized()
 
-	# Circle in the forward/up plane, offset out to the side and raised.
-	var fwd := -_character_root.global_basis.z
-	var circle_center := shoulder + outward * _tuning.arm_windmill_lateral \
-		+ Vector3.UP * _tuning.arm_windmill_height
-	var sweep := (fwd * cos(phase) + Vector3.UP * sin(phase)) * _tuning.arm_windmill_radius
-	_arm_ik.begin_reach(side, circle_center + sweep)
+	# Sweep in the plane of the FALL (stumble direction × up), not the character's facing,
+	# so the arms throw the way the body is actually being shoved — and lean into it. This
+	# ties the windmill to THIS hit instead of being a facing-locked canned circle.
+	var sweep_axis := _stumble_dir
+	if sweep_axis.length_squared() < 0.0001:
+		sweep_axis = -_character_root.global_basis.z
+	sweep_axis = sweep_axis.normalized()
+
+	var radius: float = _tuning.arm_windmill_radius * (0.4 + 0.6 * intensity)
+	var circle_center := shoulder \
+		+ outward * _tuning.arm_windmill_lateral \
+		+ Vector3.UP * _tuning.arm_windmill_height \
+		+ sweep_axis * (_tuning.arm_windmill_radius * 0.5 * intensity)  # lean into the fall
+	var sweep := (sweep_axis * cos(phase) + Vector3.UP * sin(phase)) * radius
+	# Partial weight: the windmill is a balancing TENDENCY layered over the loose flail,
+	# not a takeover — keeps the upper body reactive rather than rigidly on the circle.
+	_arm_ik.begin_reach(side, circle_center + sweep, _tuning.arm_brace_weight)
 
 
 ## Releases the arm windmill (blends the arms back toward the animation pose).

--- a/addons/kickback/active_ragdoll_controller.gd
+++ b/addons/kickback/active_ragdoll_controller.gd
@@ -93,6 +93,8 @@ var _fall_brace_timer: float = 0.0
 var _fall_brace_side: String = ""
 var _fall_brace_dir: Vector3 = Vector3.ZERO
 var _fall_brace_arm_rigs: PackedStringArray = []
+var _fall_ground_y: float = 0.0  # actual ground height under the reach (for contact)
+var _fall_brace_target: Vector3 = Vector3.ZERO  # last reach target (cached for debug HUD)
 
 # Cached semantic role rig-names, resolved from the profile (see RagdollProfile roles).
 # Consumers query these instead of hardcoding "Hips"/"Foot_L"/... so non-Mixamo rigs work.
@@ -516,6 +518,7 @@ func _apply_stumble_brace() -> void:
 func _update_arm_windmill(delta: float) -> void:
 	if not _arm_ik or not _tuning.arm_brace_enabled:
 		return
+	_arm_ik.set_physics_anchored(false)  # windmill solves against the animation pose
 	_windmill_phase += _tuning.arm_windmill_speed * delta
 	# Couple the windmill to the body's momentum: full size right after the hit, winding
 	# down as the drift is spent, so the arms settle WITH the body rather than spinning on
@@ -593,6 +596,14 @@ func _setup_fall_brace() -> void:
 		return
 	dir = dir.normalized()
 
+	# A protective ground reach is the forward/side "catch yourself" reflex. A backward
+	# fall can't be broken by a hands-forward plant — forcing it reaches behind the
+	# shoulder and contorts the arm — so skip the reach when the fall runs clearly
+	# against the character's facing (it just collapses; the stumble windmill already
+	# gave the upper body life on the way down). The character faces +Z.
+	if dir.dot(_character_root.global_basis.z) < _tuning.arm_fall_reach_min_facing:
+		return
+
 	var bodies := _rig_builder.get_bodies()
 	var side := _leading_arm_side(bodies, dir)
 	if side == "":
@@ -606,6 +617,9 @@ func _setup_fall_brace() -> void:
 	_fall_brace_arm_rigs = chain
 	_fall_brace_timer = 0.0
 	_fall_bracing = true
+	# Anchor the reach to the PHYSICAL arm (the body has left the animation pose now that
+	# it's limp) so it reaches from where the arm actually is, not a phantom standing arm.
+	_arm_ik.set_physics_anchored(true)
 	# Keep the bracing arm's springs alive (the zeroing loop in _full_ragdoll just
 	# limped them); the per-frame update re-asserts this as long as the brace holds.
 	for rig: String in chain:
@@ -638,11 +652,18 @@ func _update_fall_brace(delta: float) -> void:
 	_fall_brace_timer += delta
 
 	var target := _fall_ground_target()
-	# Hand reached the ground (or the window expired) → release to a full limp ragdoll.
+	_fall_brace_target = target  # cache for the debug HUD (no raycast in _draw)
+	# Release to a full limp ragdoll when the window expires, or once the hand has
+	# planted — but only after holding at least half the window, so the catch visibly
+	# props the body instead of limping out the instant the hand grazes the ground.
 	var hand_rig: String = _fall_brace_arm_rigs[2]
 	var bodies := _rig_builder.get_bodies()
 	var hand_body: RigidBody3D = bodies.get(hand_rig)
-	var contacted := hand_body and hand_body.global_position.y <= target.y + 0.06
+	var min_hold: float = _tuning.arm_fall_reach_duration * 0.5
+	# Contact = the hand reached the ACTUAL ground (not the possibly-mid-air clamped
+	# target), and only after holding at least the minimum so the prop is visible.
+	var contacted := hand_body and hand_body.global_position.y <= _fall_ground_y + 0.06 \
+		and _fall_brace_timer >= min_hold
 	if _fall_brace_timer >= _tuning.arm_fall_reach_duration or contacted:
 		_end_fall_brace()
 		return
@@ -654,14 +675,18 @@ func _update_fall_brace(delta: float) -> void:
 	_arm_ik.begin_reach(_fall_brace_side, target, _tuning.arm_fall_reach_weight)
 
 
-## World-space ground point the bracing hand reaches for: ahead of the hips along the
-## fall direction, dropped to the ground by a downward raycast (falls back to the
-## character root's height if nothing is hit).
+## World-space point the bracing hand reaches for. It aims at the ground ahead of the
+## body in the fall direction (downward raycast for the height), but is pulled back to
+## within the arm's reach of the actual shoulder, so the hand always extends toward the
+## ground (and plants on it once the body has fallen close enough) rather than chasing
+## an out-of-reach point and floating.
 func _fall_ground_target() -> Vector3:
 	var bodies := _rig_builder.get_bodies()
 	var hips: RigidBody3D = bodies.get(_root_rig)
 	var origin := hips.global_position if hips else _character_root.global_position
 	var ahead := origin + _fall_brace_dir * _tuning.arm_fall_reach_distance
+
+	# Ground height under the reach point (raycast; fall back to the root's height).
 	var ground_y := _character_root.global_position.y
 	var world := _character_root.get_world_3d()
 	if world:
@@ -672,7 +697,19 @@ func _fall_ground_target() -> Vector3:
 		var hit := ss.intersect_ray(q)
 		if not hit.is_empty():
 			ground_y = hit["position"].y
-	return Vector3(ahead.x, ground_y + _tuning.foot_ik_ankle_height, ahead.z)
+	var ground_point := Vector3(ahead.x, ground_y + _tuning.foot_ik_ankle_height, ahead.z)
+	_fall_ground_y = ground_point.y  # the real ground height, for the contact test
+
+	# Clamp to within the arm's reach of the physical shoulder so the IK can hit it.
+	var shoulder_body: RigidBody3D = bodies.get(_fall_brace_arm_rigs[0])
+	if not shoulder_body:
+		return ground_point
+	var shoulder := shoulder_body.global_position
+	var to_ground := ground_point - shoulder
+	var max_reach := _arm_ik.get_reach() * 0.97
+	if to_ground.length() > max_reach:
+		return shoulder + to_ground.normalized() * max_reach
+	return ground_point
 
 
 ## Ends the protective fall reach: the bracing arm goes limp (springs zeroed) and joins
@@ -927,6 +964,23 @@ func get_balance_ratio() -> float:
 ## Returns the full balance state: {com, support_center, balance_ratio, imbalance_dir}.
 func get_balance_state() -> Dictionary:
 	return _compute_balance_state()
+
+
+## Debug snapshot of the protective fall reach for the debug HUD. Returns {} when not
+## bracing, else {target, shoulder, hand, side} world-space positions (cached from the
+## last solve — no physics query, safe to call from _draw).
+func get_fall_brace_debug() -> Dictionary:
+	if not _fall_bracing or _fall_brace_arm_rigs.size() != 3 or not _rig_builder:
+		return {}
+	var bodies := _rig_builder.get_bodies()
+	var shoulder_body: RigidBody3D = bodies.get(_fall_brace_arm_rigs[0])
+	var hand_body: RigidBody3D = bodies.get(_fall_brace_arm_rigs[2])
+	return {
+		"target": _fall_brace_target,
+		"shoulder": shoulder_body.global_position if shoulder_body else _fall_brace_target,
+		"hand": hand_body.global_position if hand_body else _fall_brace_target,
+		"side": _fall_brace_side,
+	}
 
 
 ## Returns the current fatigue level (0.0 = fresh, 1.0 = exhausted).

--- a/addons/kickback/active_ragdoll_controller.gd
+++ b/addons/kickback/active_ragdoll_controller.gd
@@ -86,6 +86,14 @@ var _windmill_phase: float = 0.0
 var _arm_shoulder_l: String = ""
 var _arm_shoulder_r: String = ""
 
+# Reach-for-ground (protective fall break): when a fall commits, the leading arm stays
+# active and reaches for the ground for a short window while the rest goes limp.
+var _fall_bracing: bool = false
+var _fall_brace_timer: float = 0.0
+var _fall_brace_side: String = ""
+var _fall_brace_dir: Vector3 = Vector3.ZERO
+var _fall_brace_arm_rigs: PackedStringArray = []
+
 # Cached semantic role rig-names, resolved from the profile (see RagdollProfile roles).
 # Consumers query these instead of hardcoding "Hips"/"Foot_L"/... so non-Mixamo rigs work.
 var _root_rig: String = "Hips"
@@ -267,12 +275,14 @@ func _physics_process(delta: float) -> void:
 			_update_recovery(delta)
 
 	# IK solvers (foot + arm) share the spring's override channel and MERGE their
-	# contributions, so clear it once per frame before they run. Only in NORMAL/STAGGER
-	# (the IK-writing states); recovery in GETTING_UP owns the channel via its own
-	# set_target_overrides. Foot solves first; arm last so it wins on any shared bone.
-	match _state:
-		State.NORMAL, State.STAGGER:
-			_spring.clear_target_overrides()
+	# contributions, so clear it once per frame before they run. In NORMAL/STAGGER (the
+	# IK-writing states) and during a braced fall (RAGDOLL while reaching for ground);
+	# recovery in GETTING_UP owns the channel via its own set_target_overrides. Foot
+	# solves first; arm last so it wins on any shared bone.
+	var ik_writing := _state == State.NORMAL or _state == State.STAGGER \
+		or (_state == State.RAGDOLL and _fall_bracing)
+	if ik_writing:
+		_spring.clear_target_overrides()
 
 	# Foot IK: solve during NORMAL, pin during STAGGER, reset otherwise
 	if _foot_ik:
@@ -284,14 +294,15 @@ func _physics_process(delta: float) -> void:
 			_:
 				_foot_ik.reset()
 
-	# Arm IK: run during NORMAL/STAGGER (windmill is driven from the stumble update;
-	# NORMAL keeps processing so a released brace blends out gracefully), reset otherwise
+	# Arm IK: run during NORMAL/STAGGER (windmill, driven from the stumble update; NORMAL
+	# keeps processing so a released brace blends out gracefully) and during a braced fall
+	# (reach-for-ground, driven from the ragdoll update); reset otherwise.
 	if _arm_ik:
-		match _state:
-			State.NORMAL, State.STAGGER:
-				_arm_ik.process(delta)
-			_:
-				_arm_ik.reset()
+		if _state == State.NORMAL or _state == State.STAGGER \
+				or (_state == State.RAGDOLL and _fall_bracing):
+			_arm_ik.process(delta)
+		else:
+			_arm_ik.reset()
 
 
 func _update_fatigue_decay(delta: float) -> void:
@@ -564,7 +575,122 @@ func _end_arm_brace() -> void:
 	_arm_ik.end_reach("R")
 
 
+## Sets up the protective fall break at ragdoll commit (called from _full_ragdoll after
+## the springs are zeroed): picks the leading arm (the one furthest along the fall
+## direction) and keeps its springs alive so the reach can drive it while the rest of
+## the body goes limp. No-op without a clear fall direction or the arm IK solver.
+func _setup_fall_brace() -> void:
+	_fall_bracing = false
+	_fall_brace_arm_rigs = PackedStringArray()
+	if not _arm_ik or not _tuning.arm_fall_reach_enabled or not _rig_builder:
+		return
+
+	# Fall direction: the directed-stumble drift if there was one, else the hit direction.
+	var dir := _stumble_dir
+	if dir.length_squared() < 0.01:
+		dir = Vector3(_stagger_hit_dir.x, 0.0, _stagger_hit_dir.z)
+	if dir.length_squared() < 0.01:
+		return
+	dir = dir.normalized()
+
+	var bodies := _rig_builder.get_bodies()
+	var side := _leading_arm_side(bodies, dir)
+	if side == "":
+		return
+	var chain := _profile.get_arm_chain(side)
+	if chain.size() != 3:
+		return
+
+	_fall_brace_side = side
+	_fall_brace_dir = dir
+	_fall_brace_arm_rigs = chain
+	_fall_brace_timer = 0.0
+	_fall_bracing = true
+	# Keep the bracing arm's springs alive (the zeroing loop in _full_ragdoll just
+	# limped them); the per-frame update re-asserts this as long as the brace holds.
+	for rig: String in chain:
+		_spring.set_bone_strength(rig, _effective_base_strength(rig) * _tuning.arm_fall_reach_strength)
+
+
+## Returns "L"/"R" for the arm whose shoulder is furthest along the fall direction (the
+## one that leads into the ground), or "" if neither shoulder body is available.
+func _leading_arm_side(bodies: Dictionary, dir: Vector3) -> String:
+	var best := ""
+	var best_d := -INF
+	for entry: Array in [["L", _arm_shoulder_l], ["R", _arm_shoulder_r]]:
+		var rig: String = entry[1]
+		if rig == "":
+			continue
+		var body: RigidBody3D = bodies.get(rig)
+		if not body:
+			continue
+		var d := body.global_position.dot(dir)
+		if d > best_d:
+			best_d = d
+			best = entry[0]
+	return best
+
+
+## Advances the protective fall reach: holds the bracing arm's springs, reaches its hand
+## toward the ground ahead in the fall direction, and ends the brace (limping the arm)
+## when the window expires or the hand reaches the ground.
+func _update_fall_brace(delta: float) -> void:
+	_fall_brace_timer += delta
+
+	var target := _fall_ground_target()
+	# Hand reached the ground (or the window expired) → release to a full limp ragdoll.
+	var hand_rig: String = _fall_brace_arm_rigs[2]
+	var bodies := _rig_builder.get_bodies()
+	var hand_body: RigidBody3D = bodies.get(hand_rig)
+	var contacted := hand_body and hand_body.global_position.y <= target.y + 0.06
+	if _fall_brace_timer >= _tuning.arm_fall_reach_duration or contacted:
+		_end_fall_brace()
+		return
+
+	# Re-assert the arm's springs (nothing else should be reviving them in ragdoll) and
+	# drive the committed reach toward the ground.
+	for rig: String in _fall_brace_arm_rigs:
+		_spring.set_bone_strength(rig, _effective_base_strength(rig) * _tuning.arm_fall_reach_strength)
+	_arm_ik.begin_reach(_fall_brace_side, target, _tuning.arm_fall_reach_weight)
+
+
+## World-space ground point the bracing hand reaches for: ahead of the hips along the
+## fall direction, dropped to the ground by a downward raycast (falls back to the
+## character root's height if nothing is hit).
+func _fall_ground_target() -> Vector3:
+	var bodies := _rig_builder.get_bodies()
+	var hips: RigidBody3D = bodies.get(_root_rig)
+	var origin := hips.global_position if hips else _character_root.global_position
+	var ahead := origin + _fall_brace_dir * _tuning.arm_fall_reach_distance
+	var ground_y := _character_root.global_position.y
+	var world := _character_root.get_world_3d()
+	if world:
+		var ss := world.direct_space_state
+		var from := Vector3(ahead.x, origin.y + 0.3, ahead.z)
+		var q := PhysicsRayQueryParameters3D.create(from, from + Vector3.DOWN * 3.0)
+		q.collision_mask = _tuning.foot_ik_collision_mask
+		var hit := ss.intersect_ray(q)
+		if not hit.is_empty():
+			ground_y = hit["position"].y
+	return Vector3(ahead.x, ground_y + _tuning.foot_ik_ankle_height, ahead.z)
+
+
+## Ends the protective fall reach: the bracing arm goes limp (springs zeroed) and joins
+## the rest of the body in a full ragdoll.
+func _end_fall_brace() -> void:
+	if not _fall_bracing:
+		return
+	_fall_bracing = false
+	for rig: String in _fall_brace_arm_rigs:
+		_spring.set_bone_strength(rig, 0.0)
+	_fall_brace_arm_rigs = PackedStringArray()
+	if _arm_ik:
+		_arm_ik.reset()
+
+
 func _update_ragdoll(delta: float) -> void:
+	if _fall_bracing:
+		_update_fall_brace(delta)
 	_ragdoll_elapsed += delta
 	if _spring.is_settled(delta) or _ragdoll_elapsed > _tuning.ragdoll_force_recovery_time:
 		_start_recovery()
@@ -732,6 +858,10 @@ func _handle_normal_hit(rig_name: String, hit_dir: Vector3, effective_reduction:
 		should_ragdoll = _pain >= _tuning.pain_ragdoll_threshold
 	if should_ragdoll:
 		if _try_acquire_ragdoll_slot():
+			# No stumble preceded this direct fall — give the protective reach the fresh
+			# hit direction (and clear any stale stumble drift) so it aims correctly.
+			_stumble_dir = Vector3.ZERO
+			_stagger_hit_dir = hit_dir
 			_full_ragdoll()
 		else:
 			_start_stagger(hit_dir)  # hard cap: downgrade to the cheaper reaction
@@ -925,6 +1055,12 @@ func _full_ragdoll() -> void:
 	_spring.reset_settle_timer()
 	_spring.clear_target_overrides()
 	_ragdoll_poses.clear()
+
+	# Protective fall break: keep the leading arm active and reaching for the ground for
+	# a short window, while the rest of the body goes limp (the catch before the
+	# collapse). Re-boosts that arm's springs after the zeroing above.
+	_setup_fall_brace()
+
 	state_changed.emit(_state)
 	ragdoll_started.emit()
 
@@ -941,6 +1077,7 @@ func _full_ragdoll() -> void:
 
 
 func _start_recovery() -> void:
+	_end_fall_brace()  # release any in-flight protective reach before the get-up blend
 	_state = State.GETTING_UP
 	_recovery_elapsed = 0.0
 	state_changed.emit(_state)

--- a/addons/kickback/active_ragdoll_controller.gd
+++ b/addons/kickback/active_ragdoll_controller.gd
@@ -78,6 +78,13 @@ var _hit_guard_bodies: Dictionary = {}
 var _profile: RagdollProfile
 var _tuning: RagdollTuning
 var _foot_ik: FootIKSolver
+var _arm_ik: ArmIKSolver
+
+# Arm bracing (0.4.0 Self-Preservation): the windmill sweep phase advances while
+# stumbling; the cached shoulder rig-names anchor each arm's windmill circle.
+var _windmill_phase: float = 0.0
+var _arm_shoulder_l: String = ""
+var _arm_shoulder_r: String = ""
 
 # Cached semantic role rig-names, resolved from the profile (see RagdollProfile roles).
 # Consumers query these instead of hardcoding "Hips"/"Foot_L"/... so non-Mixamo rigs work.
@@ -165,6 +172,11 @@ func _resolve_roles() -> void:
 	_leg_rig_set.clear()
 	for leg: String in _profile.get_all_leg_rigs():
 		_leg_rig_set[leg] = true
+	# Shoulder rig-names anchor the windmill circles (chain[0] of each arm chain).
+	var arm_l := _profile.get_arm_chain("L")
+	var arm_r := _profile.get_arm_chain("R")
+	_arm_shoulder_l = arm_l[0] if arm_l.size() == 3 else ""
+	_arm_shoulder_r = arm_r[0] if arm_r.size() == 3 else ""
 
 
 func _rebuild_protected_set() -> void:
@@ -234,6 +246,14 @@ func _physics_process(delta: float) -> void:
 				push_warning("ActiveRagdollController: foot IK disabled (missing leg bones)")
 				_foot_ik = null
 
+	# Lazy arm IK init (arm bracing — same deferral as foot IK)
+	if not _arm_ik and _tuning and _tuning.arm_brace_enabled and _character_root:
+		if not _spring.get_all_bone_names().is_empty():
+			_arm_ik = ArmIKSolver.new()
+			if not _arm_ik.initialize(_spring, _tuning, _character_root, _rig_builder, _profile):
+				push_warning("ActiveRagdollController: arm bracing disabled (missing arm bones)")
+				_arm_ik = null
+
 	_update_fatigue_decay(delta)
 	_tick_reaction_pulses(delta)
 	_sync_injuries_to_resolver()
@@ -246,6 +266,14 @@ func _physics_process(delta: float) -> void:
 		State.GETTING_UP:
 			_update_recovery(delta)
 
+	# IK solvers (foot + arm) share the spring's override channel and MERGE their
+	# contributions, so clear it once per frame before they run. Only in NORMAL/STAGGER
+	# (the IK-writing states); recovery in GETTING_UP owns the channel via its own
+	# set_target_overrides. Foot solves first; arm last so it wins on any shared bone.
+	match _state:
+		State.NORMAL, State.STAGGER:
+			_spring.clear_target_overrides()
+
 	# Foot IK: solve during NORMAL, pin during STAGGER, reset otherwise
 	if _foot_ik:
 		match _state:
@@ -255,6 +283,15 @@ func _physics_process(delta: float) -> void:
 				_foot_ik.process_stagger(delta)
 			_:
 				_foot_ik.reset()
+
+	# Arm IK: run during NORMAL/STAGGER (windmill is driven from the stumble update;
+	# NORMAL keeps processing so a released brace blends out gracefully), reset otherwise
+	if _arm_ik:
+		match _state:
+			State.NORMAL, State.STAGGER:
+				_arm_ik.process(delta)
+			_:
+				_arm_ik.reset()
 
 
 func _update_fatigue_decay(delta: float) -> void:
@@ -374,6 +411,7 @@ func _update_directed_stumble(delta: float) -> void:
 		return
 	if not _tuning.stumble_enabled or not _foot_ik or not _character_root:
 		_stumbling = false
+		_end_arm_brace()
 		return
 
 	# Drift the root along the hit direction (horizontal), decaying the speed.
@@ -394,9 +432,13 @@ func _update_directed_stumble(delta: float) -> void:
 	# stays loose and reacts (differential stiffness — see _apply_stumble_brace).
 	_apply_stumble_brace()
 
+	# Windmill the arms for balance — the active upper-body layer over the loose flail.
+	_update_arm_windmill(delta)
+
 	# Stumble is over once the momentum is spent and the last step has planted.
 	if _stumble_drift <= 0.01 and not _foot_ik.is_stepping():
 		_stumbling = false
+		_end_arm_brace()  # release the windmill; the arms blend back to animation
 
 
 ## Steps the trailing foot (the one furthest back along the stumble direction) forward
@@ -453,6 +495,56 @@ func _apply_stumble_brace() -> void:
 		var target := _effective_base_strength(rig_name) * brace
 		if _spring.get_bone_strength(rig_name) < target:
 			_spring.set_bone_strength(rig_name, target)
+
+
+## Drives the arm windmill while stumbling (0.4.0 Self-Preservation): each hand sweeps
+## a wide vertical circle out to its own side, the two arms in opposite phase, so the
+## upper body actively fights for balance instead of only flailing loosely. Targets are
+## recomputed in world space each frame so the circles follow the displacing body. The
+## arm IK blends these in by weight; an unreachable point just holds the animation pose.
+func _update_arm_windmill(delta: float) -> void:
+	if not _arm_ik or not _tuning.arm_brace_enabled:
+		return
+	_windmill_phase += _tuning.arm_windmill_speed * delta
+	_drive_windmill_arm("L", _arm_shoulder_l, _windmill_phase)
+	_drive_windmill_arm("R", _arm_shoulder_r, _windmill_phase + PI)
+
+
+## Points one arm's windmill target for this frame. [param shoulder_rig] is the chain's
+## shoulder body (the circle anchor); [param phase] is its position around the sweep.
+func _drive_windmill_arm(side: String, shoulder_rig: String, phase: float) -> void:
+	if shoulder_rig == "":
+		return
+	var bodies := _rig_builder.get_bodies()
+	var shoulder_body: RigidBody3D = bodies.get(shoulder_rig)
+	if not shoulder_body:
+		return
+	var shoulder := shoulder_body.global_position
+
+	# Outward = the shoulder's horizontal offset from the body center, so each circle
+	# sits on its own side regardless of facing (falls back to the character's lateral
+	# axis if the shoulder sits on the centerline).
+	var center_body: RigidBody3D = bodies.get(_root_rig)
+	var outward := shoulder - (center_body.global_position if center_body else shoulder)
+	outward.y = 0.0
+	if outward.length_squared() < 0.0001:
+		outward = _character_root.global_basis.x * (1.0 if side == "L" else -1.0)
+	outward = outward.normalized()
+
+	# Circle in the forward/up plane, offset out to the side and raised.
+	var fwd := -_character_root.global_basis.z
+	var circle_center := shoulder + outward * _tuning.arm_windmill_lateral \
+		+ Vector3.UP * _tuning.arm_windmill_height
+	var sweep := (fwd * cos(phase) + Vector3.UP * sin(phase)) * _tuning.arm_windmill_radius
+	_arm_ik.begin_reach(side, circle_center + sweep)
+
+
+## Releases the arm windmill (blends the arms back toward the animation pose).
+func _end_arm_brace() -> void:
+	if not _arm_ik:
+		return
+	_arm_ik.end_reach("L")
+	_arm_ik.end_reach("R")
 
 
 func _update_ragdoll(delta: float) -> void:
@@ -955,6 +1047,7 @@ func _start_stagger(hit_dir: Vector3) -> void:
 		_stumble_drift = _tuning.stumble_push_speed
 		_stumble_dist_since_step = _tuning.stumble_step_length  # step on the first frame
 		_stumbling = true
+		_windmill_phase = 0.0  # arms windmill for balance for the duration of the stumble
 	else:
 		_stumble_dir = Vector3.ZERO
 		_stumble_drift = 0.0
@@ -973,6 +1066,7 @@ func _start_stagger(hit_dir: Vector3) -> void:
 func _finish_stagger() -> void:
 	if _foot_ik:
 		_foot_ik.end_stagger()
+	_end_arm_brace()
 	for rig_name: String in _spring.get_all_bone_names():
 		_spring.set_bone_strength(rig_name, _effective_base_strength(rig_name))
 	_state = State.NORMAL

--- a/addons/kickback/arm_ik_solver.gd
+++ b/addons/kickback/arm_ik_solver.gd
@@ -11,10 +11,6 @@
 class_name ArmIKSolver
 extends RefCounted
 
-# Blend rate (per second) for ramping each arm's IK weight toward its target. A
-# local constant for now; the windmill/reach feel tuning lands with the visual pass.
-const ARM_BLEND_SPEED: float = 12.0
-
 var _spring: SpringResolver
 var _tuning: RagdollTuning
 var _character_root: Node3D
@@ -174,7 +170,7 @@ func _solve(delta: float) -> void:
 	overrides.clear()
 
 	# Ramp each arm's weight toward its target (frame-rate-independent blend).
-	var blend := 1.0 - exp(-ARM_BLEND_SPEED * delta)
+	var blend := 1.0 - exp(-_tuning.arm_brace_blend_speed * delta)
 	_weight_l = lerpf(_weight_l, _target_weight_l, blend)
 	_weight_r = lerpf(_weight_r, _target_weight_r, blend)
 
@@ -183,7 +179,9 @@ func _solve(delta: float) -> void:
 	if _weight_r > 0.001:
 		_solve_arm(overrides, _upper_r, _lower_r, _hand_r, _reach_target_r, _weight_r, sg)
 
-	_spring.set_target_overrides(overrides)
+	# Merge (not replace): the controller clears the override set once per frame and the
+	# foot solver contributes first; arm runs last so it wins on any shared bone.
+	_spring.merge_target_overrides(overrides)
 
 
 ## Solves one arm toward [param target] and writes weight-blended overrides for its

--- a/addons/kickback/arm_ik_solver.gd
+++ b/addons/kickback/arm_ik_solver.gd
@@ -45,6 +45,15 @@ var _target_weight_r: float = 0.0
 var _hand_body_l: RigidBody3D
 var _hand_body_r: RigidBody3D
 
+# The rig body map, so the solver can anchor to where the arm PHYSICALLY is (see
+# _physics_anchored). Stable reference, set once at init.
+var _rig_bodies: Dictionary = {}
+# When true, the solve anchors to the arm's physical body transforms instead of the
+# animation pose. The windmill runs against the animation (springs hold the body near
+# it during a stagger); the fall reach must anchor to the limp body, which has fallen
+# away from the animation pose, or the reach is computed from a phantom standing arm.
+var _physics_anchored: bool = false
+
 var _initialized: bool = false
 
 # Per-solve scratch buffers, reused to avoid per-frame allocations (see FootIKSolver
@@ -93,10 +102,10 @@ func initialize(spring: SpringResolver, tuning: RagdollTuning, character_root: N
 	if _upper_arm_len < 0.01 or _lower_arm_len < 0.01:
 		return false
 
-	# Cache hand body refs (end-effectors) for the fall-reach contact pass.
-	var bodies := rig_builder.get_bodies()
-	_hand_body_l = bodies.get(_hand_l)
-	_hand_body_r = bodies.get(_hand_r)
+	# Cache the body map (physical anchoring) + hand refs (fall-reach contact pass).
+	_rig_bodies = rig_builder.get_bodies()
+	_hand_body_l = _rig_bodies.get(_hand_l)
+	_hand_body_r = _rig_bodies.get(_hand_r)
 
 	_initialized = true
 	return true
@@ -109,6 +118,19 @@ func is_initialized() -> bool:
 ## True while either arm's IK has any influence (mid-blend or fully reaching).
 func is_active() -> bool:
 	return _weight_l > 0.001 or _weight_r > 0.001
+
+
+## Full arm reach (upper + lower segment lengths). Lets the caller place a reach target
+## the arm can actually hit.
+func get_reach() -> float:
+	return _upper_arm_len + _lower_arm_len
+
+
+## Anchor the solve to the physical arm bodies (true) or the animation pose (false).
+## Use physical anchoring whenever the body has left the animation pose — e.g. a limp
+## fall — so the reach is computed from where the arm actually is.
+func set_physics_anchored(enabled: bool) -> void:
+	_physics_anchored = enabled
 
 
 ## True while either arm has an active reach target (regardless of blend progress).
@@ -187,25 +209,41 @@ func _solve(delta: float) -> void:
 
 
 ## Solves one arm toward [param target] and writes weight-blended overrides for its
-## three bones. The hand keeps its animation orientation (no slope concept for a
-## hand) and sits at the target; the shoulder/elbow swing to follow.
+## three bones. The hand keeps its source orientation (no slope concept for a hand) and
+## sits at the target; the shoulder/elbow swing to follow. The source pose is the arm's
+## animation pose, or its physical body pose when [member _physics_anchored] (so the
+## reach is computed from where the arm actually is, not a fallen-away animation pose).
 func _solve_arm(overrides: Dictionary, upper_name: String, lower_name: String,
 		hand_name: String, target: Vector3, weight: float, sg: Transform3D) -> void:
-	var upper_anim := _anim_global(_bone_idx[upper_name], sg)
-	var lower_anim := _anim_global(_bone_idx[lower_name], sg)
-	var hand_anim := _anim_global(_bone_idx[hand_name], sg)
+	var upper_src: Transform3D
+	var lower_src: Transform3D
+	var hand_src: Transform3D
+	if _physics_anchored:
+		upper_src = _body_global(upper_name)
+		lower_src = _body_global(lower_name)
+		hand_src = _body_global(hand_name)
+	else:
+		upper_src = _anim_global(_bone_idx[upper_name], sg)
+		lower_src = _anim_global(_bone_idx[lower_name], sg)
+		hand_src = _anim_global(_bone_idx[hand_name], sg)
 
-	var ik := TwoBoneIK.solve(_upper_arm_len, _lower_arm_len, upper_anim.origin,
-		target, lower_anim.origin, upper_anim, lower_anim, hand_anim,
+	var ik := TwoBoneIK.solve(_upper_arm_len, _lower_arm_len, upper_src.origin,
+		target, lower_src.origin, upper_src, lower_src, hand_src,
 		-_character_root.global_basis.z)
 	if ik.is_empty():
-		# Target unreachable — leave this arm at its animation pose (no override).
+		# Target unreachable — leave this arm at its source pose (no override).
 		return
 
-	var hand_ik := Transform3D(hand_anim.basis, target)
-	overrides[upper_name] = upper_anim.interpolate_with(ik["upper"], weight)
-	overrides[lower_name] = lower_anim.interpolate_with(ik["lower"], weight)
-	overrides[hand_name] = hand_anim.interpolate_with(hand_ik, weight)
+	var hand_ik := Transform3D(hand_src.basis, target)
+	overrides[upper_name] = upper_src.interpolate_with(ik["upper"], weight)
+	overrides[lower_name] = lower_src.interpolate_with(ik["lower"], weight)
+	overrides[hand_name] = hand_src.interpolate_with(hand_ik, weight)
+
+
+## World-space physical transform of a rig body (the physical-anchor source).
+func _body_global(rig_name: String) -> Transform3D:
+	var body: RigidBody3D = _rig_bodies.get(rig_name)
+	return body.global_transform if body else Transform3D.IDENTITY
 
 
 ## World-space animation global for a bone index, memoized per solve (see
@@ -227,3 +265,4 @@ func reset() -> void:
 	_target_weight_r = 0.0
 	_weight_l = 0.0
 	_weight_r = 0.0
+	_physics_anchored = false

--- a/addons/kickback/arm_ik_solver.gd
+++ b/addons/kickback/arm_ik_solver.gd
@@ -119,17 +119,19 @@ func is_reaching() -> bool:
 # ── Reach control (driven by the controller) ───────────────────────────────
 
 ## Starts driving the arm on [param side] ("L"/"R") toward the world-space
-## [param target]. The IK weight blends in over the next frames. Call
-## [method update_reach] each frame to move a windmilling/tracking target.
-func begin_reach(side: String, target: Vector3) -> void:
+## [param target], blending the IK in to [param weight] (1.0 = fully on the IK
+## solution, lower = a tendency layered over the loose physics pose). Call
+## [method update_reach] each frame to move a windmilling/tracking target, or just call
+## this again — it re-asserts the target and weight, so it's safe to call per frame.
+func begin_reach(side: String, target: Vector3, weight: float = 1.0) -> void:
 	if side == "L":
 		_reach_target_l = target
 		_reach_active_l = true
-		_target_weight_l = 1.0
+		_target_weight_l = weight
 	elif side == "R":
 		_reach_target_r = target
 		_reach_active_r = true
-		_target_weight_r = 1.0
+		_target_weight_r = weight
 
 
 ## Moves an already-active reach target without changing its blend (use to animate a

--- a/addons/kickback/foot_ik_solver.gd
+++ b/addons/kickback/foot_ik_solver.gd
@@ -1,6 +1,6 @@
 ## Two-bone foot IK solver for planting feet on uneven terrain.
-## Uses direct math (law of cosines) computed in _physics_process, feeding
-## results to SpringResolver.set_target_overrides(). Does NOT use TwoBoneIK3D
+## Uses direct math (law of cosines) computed in _physics_process, merging its
+## results into SpringResolver's target overrides. Does NOT use TwoBoneIK3D
 ## because PhysicsRigSync contaminates SkeletonModifier3D bone pose readings.
 ##
 ## Owned by ActiveRagdollController. Called during NORMAL state (full solve),
@@ -386,7 +386,10 @@ func _solve_ik(delta: float, use_pins: bool) -> void:
 			_blend_leg(overrides, _upper_r, _lower_r, _foot_r,
 				upper_r, lower_r, foot_r, ik, _ik_weight_r, ps)
 
-	_spring.set_target_overrides(overrides)
+	# Merge (not replace): the controller clears the override set once per frame, then
+	# the foot and arm solvers each contribute their bones. Foot runs first; arm IK
+	# overwrites the (anim-pose) arm entries this may write during a pelvis shift.
+	_spring.merge_target_overrides(overrides)
 
 
 ## Returns the world-space animation global for a bone index, memoized per solve

--- a/addons/kickback/resources/ragdoll_tuning.gd
+++ b/addons/kickback/resources/ragdoll_tuning.gd
@@ -375,18 +375,18 @@ extends Resource
 @export_range(0.0, 1.0) var stumble_step_threshold: float = 0.45
 ## Base horizontal step distance (meters), scaled by balance ratio so a harder tip
 ## takes a bigger step.
-@export_range(0.0, 1.0) var stumble_step_length: float = 0.35
+@export_range(0.0, 1.0) var stumble_step_length: float = 0.20
 ## Maximum horizontal reach of a step target from the foot's current position
 ## (meters). Clamps the balance-scaled step so the leg never overstretches.
 @export_range(0.1, 1.5) var stumble_step_reach_max: float = 0.6
 ## Time for the stepping foot to travel from its current position to the step
 ## target (seconds).
-@export_range(0.05, 1.0) var stumble_step_duration: float = 0.25
+@export_range(0.05, 1.0) var stumble_step_duration: float = 0.18
 ## Minimum time between consecutive stumble steps (seconds). Produces discrete
 ## catch-steps rather than a foot sliding continuously.
 @export_range(0.0, 1.0) var stumble_step_cooldown: float = 0.3
 ## Maximum number of catch-steps in one stagger before giving up and ragdolling.
-@export_range(1, 5) var stumble_max_steps: int = 2
+@export_range(1, 5) var stumble_max_steps: int = 3
 ## Spring strength (as a fraction of each bone's base) applied WHILE stumbling. A
 ## real stumble tenses the body and steps — not a foot reposition on a limp ragdoll —
 ## so during the stumble the springs stiffen toward this level so the body stays
@@ -398,7 +398,7 @@ extends Resource
 ## character root drifts in the hit direction at this speed, so the stumble visibly
 ## DISPLACES the character (you stumble where you're shoved) rather than shuffling in
 ## place. Decays via [member stumble_push_decel]. 0.0 = no displacement (in-place).
-@export_range(0.0, 6.0) var stumble_push_speed: float = 2.0
+@export_range(0.0, 6.0) var stumble_push_speed: float = 2.3
 ## Deceleration (m/s²) of the knockback drift — how fast the stumble momentum is
 ## absorbed. Total stumble distance ≈ speed² / (2·decel). Higher = shorter stumble.
 @export_range(0.5, 20.0) var stumble_push_decel: float = 7.0
@@ -414,21 +414,25 @@ extends Resource
 ## in wide vertical circles) to fight for balance — the active upper-body layer on top
 ## of the loose flailing. Requires the arm IK solver (arm-chain roles). 0.4.0.
 @export var arm_brace_enabled: bool = true
+## How strongly the windmill drives the arms (0..1). This is a TENDENCY layered over
+## the loose physics pose, not a takeover: lower keeps the arms reactive and organic
+## (they only lean toward the windmill), 1.0 pins them rigidly to the geometric circle.
+@export_range(0.0, 1.0) var arm_brace_weight: float = 0.55
 ## Radius (meters) of the windmill circle each hand sweeps. Larger = bigger, wilder
 ## arcs. Kept within the arm's reach so the solve never overstretches.
-@export_range(0.0, 0.5) var arm_windmill_radius: float = 0.32
+@export_range(0.0, 0.5) var arm_windmill_radius: float = 0.24
 ## Outward offset (meters) of each windmill circle from the shoulder, along the body's
 ## lateral axis, so the arms circle out to their own sides instead of across the chest.
 @export_range(0.0, 0.5) var arm_windmill_lateral: float = 0.16
 ## Vertical offset (meters) of each windmill circle's center above the shoulder, so the
 ## arms sweep up high (a raised, balancing flail) rather than down at the hips.
-@export_range(-0.3, 0.5) var arm_windmill_height: float = 0.12
+@export_range(-0.3, 0.5) var arm_windmill_height: float = 0.1
 ## Angular speed (rad/s) of the windmill sweep. Higher = faster spinning arms. The two
 ## arms sweep in opposite phase, so this also sets how fast they alternate.
-@export_range(0.0, 30.0) var arm_windmill_speed: float = 9.0
+@export_range(0.0, 30.0) var arm_windmill_speed: float = 6.0
 ## Blend rate (per second) the arm IK weight ramps in/out over. Higher = the arms snap
 ## into the brace faster; lower = they ease in.
-@export_range(1.0, 40.0) var arm_brace_blend_speed: float = 12.0
+@export_range(1.0, 40.0) var arm_brace_blend_speed: float = 10.0
 
 
 ## Creates a RagdollTuning with standard defaults. Equivalent to RagdollTuning.new()

--- a/addons/kickback/resources/ragdoll_tuning.gd
+++ b/addons/kickback/resources/ragdoll_tuning.gd
@@ -433,6 +433,23 @@ extends Resource
 ## Blend rate (per second) the arm IK weight ramps in/out over. Higher = the arms snap
 ## into the brace faster; lower = they ease in.
 @export_range(1.0, 40.0) var arm_brace_blend_speed: float = 10.0
+## Reach-for-ground: when a hit commits to a FALL (the character tips over to ragdoll),
+## the leading arm extends toward the ground to break it — the protective half of arm
+## bracing. The arm stays active for a short window while the rest of the body goes
+## limp, then releases. Requires the arm IK solver. 0.4.0.
+@export var arm_fall_reach_enabled: bool = true
+## Seconds the bracing arm stays active into the fall before it goes fully limp — the
+## window in which the arm protectively reaches. After it, the whole body ragdolls.
+@export_range(0.0, 1.5) var arm_fall_reach_duration: float = 0.5
+## Spring strength (fraction of base) held on the bracing arm during the fall window
+## while the rest of the body goes limp. Higher = a stiffer, more committed catch.
+@export_range(0.0, 1.0) var arm_fall_reach_strength: float = 0.6
+## How far ahead of the body (along the fall direction) the ground reach target sits
+## (meters). The hand reaches down and forward, into the fall.
+@export_range(0.0, 1.0) var arm_fall_reach_distance: float = 0.4
+## How strongly the IK drives the bracing arm toward the ground target (0..1). Higher
+## than the windmill — a committed reach, not a tendency.
+@export_range(0.0, 1.0) var arm_fall_reach_weight: float = 0.9
 
 
 ## Creates a RagdollTuning with standard defaults. Equivalent to RagdollTuning.new()

--- a/addons/kickback/resources/ragdoll_tuning.gd
+++ b/addons/kickback/resources/ragdoll_tuning.gd
@@ -407,6 +407,30 @@ extends Resource
 @export_range(0.0, 0.3) var stumble_step_lift: float = 0.1
 
 
+# ── Self-Preservation: Arm Bracing ──────────────────────────────────────────
+
+@export_group("Self-Preservation: Arm Bracing")
+## Enable procedural arm bracing: during a directed stumble the arms windmill (sweep
+## in wide vertical circles) to fight for balance — the active upper-body layer on top
+## of the loose flailing. Requires the arm IK solver (arm-chain roles). 0.4.0.
+@export var arm_brace_enabled: bool = true
+## Radius (meters) of the windmill circle each hand sweeps. Larger = bigger, wilder
+## arcs. Kept within the arm's reach so the solve never overstretches.
+@export_range(0.0, 0.5) var arm_windmill_radius: float = 0.32
+## Outward offset (meters) of each windmill circle from the shoulder, along the body's
+## lateral axis, so the arms circle out to their own sides instead of across the chest.
+@export_range(0.0, 0.5) var arm_windmill_lateral: float = 0.16
+## Vertical offset (meters) of each windmill circle's center above the shoulder, so the
+## arms sweep up high (a raised, balancing flail) rather than down at the hips.
+@export_range(-0.3, 0.5) var arm_windmill_height: float = 0.12
+## Angular speed (rad/s) of the windmill sweep. Higher = faster spinning arms. The two
+## arms sweep in opposite phase, so this also sets how fast they alternate.
+@export_range(0.0, 30.0) var arm_windmill_speed: float = 9.0
+## Blend rate (per second) the arm IK weight ramps in/out over. Higher = the arms snap
+## into the brace faster; lower = they ease in.
+@export_range(1.0, 40.0) var arm_brace_blend_speed: float = 12.0
+
+
 ## Creates a RagdollTuning with standard defaults. Equivalent to RagdollTuning.new()
 ## since all property defaults are pre-populated.
 static func create_default() -> RagdollTuning:

--- a/addons/kickback/resources/ragdoll_tuning.gd
+++ b/addons/kickback/resources/ragdoll_tuning.gd
@@ -375,13 +375,13 @@ extends Resource
 @export_range(0.0, 1.0) var stumble_step_threshold: float = 0.45
 ## Base horizontal step distance (meters), scaled by balance ratio so a harder tip
 ## takes a bigger step.
-@export_range(0.0, 1.0) var stumble_step_length: float = 0.20
+@export_range(0.0, 1.0) var stumble_step_length: float = 0.24
 ## Maximum horizontal reach of a step target from the foot's current position
 ## (meters). Clamps the balance-scaled step so the leg never overstretches.
 @export_range(0.1, 1.5) var stumble_step_reach_max: float = 0.6
 ## Time for the stepping foot to travel from its current position to the step
 ## target (seconds).
-@export_range(0.05, 1.0) var stumble_step_duration: float = 0.18
+@export_range(0.05, 1.0) var stumble_step_duration: float = 0.24
 ## Minimum time between consecutive stumble steps (seconds). Produces discrete
 ## catch-steps rather than a foot sliding continuously.
 @export_range(0.0, 1.0) var stumble_step_cooldown: float = 0.3
@@ -393,7 +393,7 @@ extends Resource
 ## upright as it lurches. Transient (only while [member _stumbling]); relaxes to the
 ## stagger floor when the stumble ends. Higher = stiffer/more upright; too high reads
 ## as a snap. 0.0 = no stiffening.
-@export_range(0.0, 1.0) var stumble_brace_strength: float = 0.7
+@export_range(0.0, 1.0) var stumble_brace_strength: float = 0.6
 ## Initial knockback speed (m/s) of the directed stumble: on a staggering hit the
 ## character root drifts in the hit direction at this speed, so the stumble visibly
 ## DISPLACES the character (you stumble where you're shoved) rather than shuffling in
@@ -417,7 +417,7 @@ extends Resource
 ## How strongly the windmill drives the arms (0..1). This is a TENDENCY layered over
 ## the loose physics pose, not a takeover: lower keeps the arms reactive and organic
 ## (they only lean toward the windmill), 1.0 pins them rigidly to the geometric circle.
-@export_range(0.0, 1.0) var arm_brace_weight: float = 0.55
+@export_range(0.0, 1.0) var arm_brace_weight: float = 0.5
 ## Radius (meters) of the windmill circle each hand sweeps. Larger = bigger, wilder
 ## arcs. Kept within the arm's reach so the solve never overstretches.
 @export_range(0.0, 0.5) var arm_windmill_radius: float = 0.24
@@ -429,10 +429,10 @@ extends Resource
 @export_range(-0.3, 0.5) var arm_windmill_height: float = 0.1
 ## Angular speed (rad/s) of the windmill sweep. Higher = faster spinning arms. The two
 ## arms sweep in opposite phase, so this also sets how fast they alternate.
-@export_range(0.0, 30.0) var arm_windmill_speed: float = 6.0
+@export_range(0.0, 30.0) var arm_windmill_speed: float = 5.0
 ## Blend rate (per second) the arm IK weight ramps in/out over. Higher = the arms snap
 ## into the brace faster; lower = they ease in.
-@export_range(1.0, 40.0) var arm_brace_blend_speed: float = 10.0
+@export_range(1.0, 40.0) var arm_brace_blend_speed: float = 8.0
 ## Reach-for-ground: when a hit commits to a FALL (the character tips over to ragdoll),
 ## the leading arm extends toward the ground to break it — the protective half of arm
 ## bracing. The arm stays active for a short window while the rest of the body goes
@@ -440,16 +440,21 @@ extends Resource
 @export var arm_fall_reach_enabled: bool = true
 ## Seconds the bracing arm stays active into the fall before it goes fully limp — the
 ## window in which the arm protectively reaches. After it, the whole body ragdolls.
-@export_range(0.0, 1.5) var arm_fall_reach_duration: float = 0.5
+@export_range(0.0, 1.5) var arm_fall_reach_duration: float = 0.55
 ## Spring strength (fraction of base) held on the bracing arm during the fall window
 ## while the rest of the body goes limp. Higher = a stiffer, more committed catch.
-@export_range(0.0, 1.0) var arm_fall_reach_strength: float = 0.6
+@export_range(0.0, 1.0) var arm_fall_reach_strength: float = 0.8
 ## How far ahead of the body (along the fall direction) the ground reach target sits
 ## (meters). The hand reaches down and forward, into the fall.
-@export_range(0.0, 1.0) var arm_fall_reach_distance: float = 0.4
+@export_range(0.0, 1.0) var arm_fall_reach_distance: float = 0.5
 ## How strongly the IK drives the bracing arm toward the ground target (0..1). Higher
 ## than the windmill — a committed reach, not a tendency.
-@export_range(0.0, 1.0) var arm_fall_reach_weight: float = 0.9
+@export_range(0.0, 1.0) var arm_fall_reach_weight: float = 0.95
+## Minimum alignment between the fall direction and the character's facing for the
+## protective reach to fire (fall·forward). Forward fall = +1, sideways = 0, backward =
+## -1. Below this the fall runs too far backward for a hands-forward catch (the arm
+## would contort reaching behind), so the reach is skipped. -1 = always reach.
+@export_range(-1.0, 1.0) var arm_fall_reach_min_facing: float = -0.25
 
 
 ## Creates a RagdollTuning with standard defaults. Equivalent to RagdollTuning.new()

--- a/addons/kickback/spring_resolver.gd
+++ b/addons/kickback/spring_resolver.gd
@@ -306,6 +306,14 @@ func set_target_overrides(overrides: Dictionary) -> void:
 	_target_overrides = overrides
 
 
+## Merges target pose overrides into the current set (later keys win), so several IK
+## contributors (foot + arm) can write the same frame without clobbering each other.
+## The controller clears the set once per frame before the solvers run, so stale keys
+## don't accumulate.
+func merge_target_overrides(overrides: Dictionary) -> void:
+	_target_overrides.merge(overrides, true)
+
+
 ## Clears all target pose overrides, reverting to animation-driven targets.
 func clear_target_overrides() -> void:
 	_target_overrides.clear()

--- a/addons/kickback/strength_debug_hud.gd
+++ b/addons/kickback/strength_debug_hud.gd
@@ -137,12 +137,44 @@ func _draw_active_target(target: Dictionary, camera: Camera3D, cam_pos: Vector3)
 	if _detail_level >= 2 and active_ctrl:
 		_draw_state_label(bodies, active_ctrl, camera, cam_pos)
 
+	# Protective fall reach (level 2+): show where the bracing arm is reaching
+	if _detail_level >= 2 and active_ctrl:
+		_draw_fall_brace(active_ctrl, camera)
+
 	# Full panel + CoM + velocity (level 3)
 	if _detail_level >= 3:
 		if active_ctrl:
 			_draw_status_panel(bodies, spring, active_ctrl, camera, cam_pos)
 		_draw_com_and_support(bodies, active_ctrl, camera, cam_pos)
 		_draw_velocity_vectors(bodies, camera, cam_pos)
+
+
+## Visualizes the protective fall reach: the reach line from the bracing shoulder to its
+## ground target, the target marker, and the hand, so you can see what the arm is aiming
+## at during a fall (the motion alone can be hard to read).
+func _draw_fall_brace(ctrl: ActiveRagdollController, camera: Camera3D) -> void:
+	var dbg := ctrl.get_fall_brace_debug()
+	if dbg.is_empty():
+		return
+	var shoulder: Vector3 = dbg["shoulder"]
+	var target: Vector3 = dbg["target"]
+	var hand: Vector3 = dbg["hand"]
+	var col := Color(1.0, 0.45, 0.1, 0.95)  # orange — the protective reach
+
+	# Reach line: shoulder → target.
+	if not camera.is_position_behind(shoulder) and not camera.is_position_behind(target):
+		draw_line(camera.unproject_position(shoulder), camera.unproject_position(target), col, 2.5)
+
+	# Target marker + label.
+	if not camera.is_position_behind(target):
+		var ts := camera.unproject_position(target)
+		draw_circle(ts, 7.0, Color(col.r, col.g, col.b, 0.3))
+		draw_arc(ts, 9.0, 0.0, TAU, 18, col, 2.0)
+		_draw_text_shadowed(ts + Vector2(11, 4), "REACH %s" % str(dbg.get("side", "")), FONT_SIZE, col)
+
+	# Hand position (the end-effector being driven).
+	if not camera.is_position_behind(hand):
+		draw_circle(camera.unproject_position(hand), 5.0, col)
 
 
 func _draw_bone_dots(bodies: Dictionary, spring: SpringResolver, camera: Camera3D, cam_pos: Vector3) -> void:

--- a/demo/tuning_playground.gd
+++ b/demo/tuning_playground.gd
@@ -166,6 +166,29 @@ func _build_slider_panel() -> void:
 	_add_slider(panel, "ik_foot_blend", 1.0, 30.0, _custom_tuning.foot_ik_foot_blend_speed)
 	_add_slider(panel, "ik_stagger_leg_str", 0.1, 1.0, _custom_tuning.foot_ik_stagger_leg_strength)
 
+	_add_section(panel, "STUMBLE (self-preservation)")
+	_add_slider(panel, "stumble_push_speed", 0.0, 6.0, _custom_tuning.stumble_push_speed)
+	_add_slider(panel, "stumble_push_decel", 0.5, 20.0, _custom_tuning.stumble_push_decel)
+	_add_slider(panel, "stumble_step_length", 0.0, 1.0, _custom_tuning.stumble_step_length)
+	_add_slider(panel, "stumble_step_duration", 0.05, 1.0, _custom_tuning.stumble_step_duration)
+	_add_slider(panel, "stumble_max_steps", 1, 5, _custom_tuning.stumble_max_steps)
+	_add_slider(panel, "stumble_brace_str", 0.0, 1.0, _custom_tuning.stumble_brace_strength)
+
+	_add_section(panel, "ARM WINDMILL")
+	_add_slider(panel, "arm_brace_weight", 0.0, 1.0, _custom_tuning.arm_brace_weight)
+	_add_slider(panel, "arm_windmill_radius", 0.0, 0.5, _custom_tuning.arm_windmill_radius)
+	_add_slider(panel, "arm_windmill_speed", 0.0, 30.0, _custom_tuning.arm_windmill_speed)
+	_add_slider(panel, "arm_windmill_lateral", 0.0, 0.5, _custom_tuning.arm_windmill_lateral)
+	_add_slider(panel, "arm_windmill_height", -0.3, 0.5, _custom_tuning.arm_windmill_height)
+	_add_slider(panel, "arm_brace_blend", 1.0, 40.0, _custom_tuning.arm_brace_blend_speed)
+
+	_add_section(panel, "ARM FALL REACH")
+	_add_slider(panel, "fall_reach_duration", 0.0, 1.5, _custom_tuning.arm_fall_reach_duration)
+	_add_slider(panel, "fall_reach_strength", 0.0, 1.0, _custom_tuning.arm_fall_reach_strength)
+	_add_slider(panel, "fall_reach_distance", 0.0, 1.0, _custom_tuning.arm_fall_reach_distance)
+	_add_slider(panel, "fall_reach_weight", 0.0, 1.0, _custom_tuning.arm_fall_reach_weight)
+	_add_slider(panel, "fall_reach_min_facing", -1.0, 1.0, _custom_tuning.arm_fall_reach_min_facing)
+
 
 func _add_section(parent: Control, title: String) -> void:
 	var spacer := Control.new()
@@ -254,6 +277,26 @@ func _on_slider_changed(param_name: String, value: float) -> void:
 		"ik_pelvis_blend": _custom_tuning.foot_ik_pelvis_blend_speed = value
 		"ik_foot_blend": _custom_tuning.foot_ik_foot_blend_speed = value
 		"ik_stagger_leg_str": _custom_tuning.foot_ik_stagger_leg_strength = value
+		# Self-preservation: stumble
+		"stumble_push_speed": _custom_tuning.stumble_push_speed = value
+		"stumble_push_decel": _custom_tuning.stumble_push_decel = value
+		"stumble_step_length": _custom_tuning.stumble_step_length = value
+		"stumble_step_duration": _custom_tuning.stumble_step_duration = value
+		"stumble_max_steps": _custom_tuning.stumble_max_steps = int(value)
+		"stumble_brace_str": _custom_tuning.stumble_brace_strength = value
+		# Self-preservation: arm windmill
+		"arm_brace_weight": _custom_tuning.arm_brace_weight = value
+		"arm_windmill_radius": _custom_tuning.arm_windmill_radius = value
+		"arm_windmill_speed": _custom_tuning.arm_windmill_speed = value
+		"arm_windmill_lateral": _custom_tuning.arm_windmill_lateral = value
+		"arm_windmill_height": _custom_tuning.arm_windmill_height = value
+		"arm_brace_blend": _custom_tuning.arm_brace_blend_speed = value
+		# Self-preservation: arm fall reach
+		"fall_reach_duration": _custom_tuning.arm_fall_reach_duration = value
+		"fall_reach_strength": _custom_tuning.arm_fall_reach_strength = value
+		"fall_reach_distance": _custom_tuning.arm_fall_reach_distance = value
+		"fall_reach_weight": _custom_tuning.arm_fall_reach_weight = value
+		"fall_reach_min_facing": _custom_tuning.arm_fall_reach_min_facing = value
 
 
 # --- Shooting ---

--- a/docs/SELF_PRESERVATION.md
+++ b/docs/SELF_PRESERVATION.md
@@ -76,31 +76,46 @@ The stumble is the middle band — the visible "shoved and recovered" reaction.
   step animation (lerp + lift arc), reusing the existing stagger pin/IK/override plumbing.
 - Signal: `stumble_step_started(foot_rig, target)`.
 
-## Arm bracing — next
+## Arm bracing
 
-The arms get an active layer (right now they only react passively because they're loose):
-- **Windmill** — arms swing wide to fight for balance during a stumble.
-- **Reach** — when a fall is committed, the leading arm reaches toward the ground to
-  break the fall.
+The upper-body active layer, so the whole reaction reads together (before this, the arms
+only reacted passively because they're loose):
 
-**Groundwork done.** `RagdollProfile` arm-chain roles (`get_arm_chain`, mirroring the leg
-chains) and the `ArmIKSolver` exist. The two-bone math (law of cosines + swing-of-animation
-basis) is factored out of `FootIKSolver` into a shared, stateless `TwoBoneIK` util that both
-solvers use, so there's no duplication; the foot IK refactor is behavior-preserving (idle
-foot buzz unchanged within physics noise). `ArmIKSolver` mirrors `FootIKSolver`: it drives an
-arm to reach a world-space target and blends its IK weight in/out (`begin_reach`/
-`update_reach`/`end_reach`), resolving arms through the arm-chain roles.
+- **Windmill** — during a directed stumble the arms swing wide to fight for balance. Each
+  hand sweeps a wide vertical circle out to its own side, the two arms in opposite phase.
+  The arc is **coupled to the stumble's momentum** (full at impact, winding down as the
+  drift spends) and **aligned to the fall direction** (sweeps in the plane of the shove and
+  leans into it), so it reads as a reaction to *this* hit, not a canned loop. It's layered
+  at **partial weight** over the loose flail — a balancing tendency, not a rigid takeover.
+- **Reach for the ground** — when a hit commits to a fall, the **leading arm** (the shoulder
+  furthest along the fall direction) reaches toward the ground to break it. Because a limp
+  ragdoll has left its animation pose, this can't be solved from animation: a brief braced
+  window keeps that arm's springs alive and runs the IK **anchored to the physical arm**,
+  driving the hand toward a ground point within reach while the rest of the body goes limp,
+  then releases into the full ragdoll (on contact or when the window expires). It's gated to
+  **forward/side falls** — a backward fall can't be broken by a hands-forward plant, and
+  forcing it just contorts the arm.
 
-**Still to come (the visual pass):** wiring the controller to *trigger* the windmill arc
-during the directed stumble and the ground reach on a committed fall, plus the feel tuning —
-and the override-channel coordination so arm IK and foot IK can write the spring at the same
-time (each currently replaces the whole override set, which is fine while only one runs).
+**How it's built.** `RagdollProfile` arm-chain roles (`get_arm_chain`, mirroring the leg
+chains) + the `ArmIKSolver`, which mirrors `FootIKSolver`: it drives an arm to a world-space
+target and blends its IK weight in/out (`begin_reach`/`update_reach`/`end_reach`), with an
+animation-anchored mode (windmill) and a physics-anchored mode (fall reach). The two-bone
+math (law of cosines + swing-of-animation basis) is factored out of `FootIKSolver` into a
+shared, stateless `TwoBoneIK` util both solvers use — no duplication; the foot IK refactor is
+behavior-preserving (idle foot buzz unchanged within physics noise). Foot IK and arm IK share
+the spring's override channel by **merging** into a per-frame-cleared set (foot first, arm
+last), so both can write the same frame without clobbering. The controller triggers the
+windmill from the stumble update and the reach from the ragdoll commit; tuning lives in the
+`RagdollTuning` "Self-Preservation: Arm Bracing" group, with live sliders in the Tuning Lab
+and a fall-reach target gizmo in the F3 debug HUD.
 
 ## State-machine integration
 
 No new states. The directed stumble lives inside `STAGGER` (`_update_directed_stumble`,
-called from `_update_stagger`) and commits across the tip-over check. Arm bracing will
-span the `STAGGER`→`RAGDOLL` transition.
+called from `_update_stagger`) and commits across the tip-over check. Arm bracing spans the
+`STAGGER`→`RAGDOLL` transition: the windmill runs in `STAGGER` (driven from the stumble
+update), and the fall reach runs at the `RAGDOLL` commit (set up in `_full_ragdoll`, advanced
+in `_update_ragdoll`) — keeping the bracing arm's springs alive into the otherwise-limp fall.
 
 ## Testing
 
@@ -111,5 +126,14 @@ Following the project pattern (drive the *real* classes via `test/helpers/rig_ha
   the behavior suppresses both. The synthetic rig's emergent fall is too nonlinear to
   assert a *physical* catch outcome, so motion *quality* is validated visually on the
   real ybot, not asserted.
-- **Arm roles / `ArmIKSolver`** (to come) — pure-data accessor tests and a reach test,
-  as for the leg chains / foot IK.
+- **Arm roles** (`test/test_ragdoll_profile_roles.gd`) — pure-data accessor tests, as for
+  the leg chains.
+- **`TwoBoneIK`** (`test/test_two_bone_ik.gd`) — pure math: swing degeneracies, segment-
+  length invariants, identity when no adjustment is needed.
+- **`ArmIKSolver`** (`test/test_arm_ik.gd`) — the real solver on a live rig: reach drives the
+  hand to target, unreachable targets no-op, weight blends out on release, and the
+  physics-anchored mode reaches from the body pose.
+- **Fall reach** (`test/test_fall_brace.gd`) — drives the real controller: a forward fall
+  keeps the leading arm alive while the rest goes limp, a backward fall skips the reach (the
+  `min_facing` gate, which is configurable), and the brace releases after its window. The
+  reach *motion* is validated visually; the tests assert the state-machine wiring.

--- a/test/test_arm_ik.gd
+++ b/test/test_arm_ik.gd
@@ -88,6 +88,8 @@ func test_initializes_and_reads_arm_lengths():
 	# Lengths derived from the synthetic skeleton's rest poses (0.28 m + 0.25 m).
 	assert_almost_eq(solver._upper_arm_len, 0.28, 0.02, "upper arm length read from rest")
 	assert_almost_eq(solver._lower_arm_len, 0.25, 0.02, "lower arm length read from rest")
+	# Full reach = the two segments summed.
+	assert_almost_eq(solver.get_reach(), 0.53, 0.03, "reach sums the arm segments")
 
 
 func test_reach_drives_hand_to_target():
@@ -121,6 +123,25 @@ func test_unreachable_target_leaves_arm_at_anim():
 	assert_gt(solver._weight_r, 0.9, "weight still ramps even when unreachable")
 	assert_false(solver._overrides_buf.has("Hand_R"),
 		"unreachable target writes no override (arm stays at animation pose)")
+
+
+# Physics-anchored mode (used by the fall reach) solves from the arm's physical body
+# pose rather than the animation pose. At rest the bodies sit on the animation pose, so
+# the hand still reaches the target — but the solve now tracks the body, not the anim.
+func test_physics_anchored_reach_drives_hand():
+	var h = await _spawn()
+	var solver = _make_solver(h)
+	solver.set_physics_anchored(true)
+	var shoulder_body: RigidBody3D = h.rig_builder.get_bodies().get("UpperArm_R")
+	assert_not_null(shoulder_body)
+	var target := shoulder_body.global_position + Vector3(-0.2, -0.2, 0.15)
+	solver.begin_reach("R", target, 1.0)
+	_pump(solver, 50)
+	assert_gt(solver._weight_r, 0.9, "physics-anchored arm blended in")
+	assert_true(solver._overrides_buf.has("Hand_R"), "physics-anchored hand override written")
+	var hand_t: Transform3D = solver._overrides_buf["Hand_R"]
+	assert_almost_eq(hand_t.origin.distance_to(target), 0.0, 0.03,
+		"physics-anchored hand reaches the target")
 
 
 func test_end_reach_blends_weight_out():

--- a/test/test_fall_brace.gd
+++ b/test/test_fall_brace.gd
@@ -1,0 +1,89 @@
+extends GutTest
+
+
+# ── Protective fall-reach tests ─────────────────────────────────────────────
+# Drives the REAL ActiveRagdollController on a live harness rig: a hit that
+# commits to a fall should keep the leading arm active and reaching for the
+# ground while the rest goes limp, gated to forward/side falls. The reach MOTION
+# is validated visually; these assert the state-machine wiring (which arm stays
+# alive, the facing gate, the release).
+
+const RigHarness := preload("res://test/helpers/rig_harness.gd")
+
+
+func _spawn():
+	var h = RigHarness.new()
+	add_child_autoqfree(h)
+	h.setup(RagdollTuning.create_default(), null, true)  # foot IK + arm bracing on
+	var ok: bool = await h.await_ready(40)
+	assert_true(ok, "Kickback setup completed within frame budget")
+	# Step physics so the controller lazily creates the foot + arm IK solvers.
+	await wait_physics_frames(15)
+	return h
+
+
+# A profile that always ragdolls, so apply_hit commits straight to a fall.
+func _fall_profile() -> ImpactProfile:
+	var p := ImpactProfile.create_bullet()
+	p.ragdoll_probability = 1.0
+	return p
+
+
+func _chest(h) -> RigidBody3D:
+	return h.rig_builder.get_bodies().get("Chest")
+
+
+# The harness character root faces +Z, so a +Z hit is a forward fall.
+func test_forward_fall_braces_leading_arm():
+	var h = await _spawn()
+	var ctrl = h.controller
+	var chest := _chest(h)
+	ctrl.apply_hit(chest, Vector3(0, 0, 1), chest.global_position, _fall_profile())
+
+	assert_eq(ctrl.get_state(), ActiveRagdollController.State.RAGDOLL, "hit committed to a fall")
+	assert_true(ctrl._fall_bracing, "forward fall engages the protective reach")
+
+	var arm_rigs: PackedStringArray = ctrl._fall_brace_arm_rigs
+	assert_eq(arm_rigs.size(), 3, "a full arm chain is bracing")
+	# The bracing arm keeps spring strength; the rest of the body goes limp.
+	assert_gt(h.spring.get_bone_strength(arm_rigs[0]), 0.01, "bracing shoulder stays active")
+	assert_gt(h.spring.get_bone_strength(arm_rigs[2]), 0.01, "bracing hand stays active")
+	assert_lt(h.spring.get_bone_strength("UpperLeg_L"), 0.01, "non-bracing bones go limp")
+	assert_lt(h.spring.get_bone_strength("UpperLeg_R"), 0.01, "non-bracing bones go limp")
+
+
+# A backward fall can't be broken by a hands-forward plant — the reach is skipped.
+func test_backward_fall_does_not_brace():
+	var h = await _spawn()
+	var ctrl = h.controller
+	var chest := _chest(h)
+	ctrl.apply_hit(chest, Vector3(0, 0, -1), chest.global_position, _fall_profile())
+
+	assert_eq(ctrl.get_state(), ActiveRagdollController.State.RAGDOLL, "hit committed to a fall")
+	assert_false(ctrl._fall_bracing, "a backward fall skips the hands-forward reach")
+	# Everything is limp on a backward fall (no arm kept alive).
+	assert_lt(h.spring.get_bone_strength("UpperArm_L"), 0.01, "arms limp on a backward fall")
+	assert_lt(h.spring.get_bone_strength("UpperArm_R"), 0.01, "arms limp on a backward fall")
+
+
+# The min-facing gate is configurable: -1 means always reach (even backward).
+func test_min_facing_can_force_reach():
+	var h = await _spawn()
+	h.tuning.arm_fall_reach_min_facing = -1.0
+	var ctrl = h.controller
+	var chest := _chest(h)
+	ctrl.apply_hit(chest, Vector3(0, 0, -1), chest.global_position, _fall_profile())
+	assert_true(ctrl._fall_bracing, "min_facing = -1 reaches even on a backward fall")
+
+
+# The brace is a brief window; after it the arm releases and joins the full ragdoll.
+func test_fall_brace_releases_after_window():
+	var h = await _spawn()
+	var ctrl = h.controller
+	var chest := _chest(h)
+	ctrl.apply_hit(chest, Vector3(0, 0, 1), chest.global_position, _fall_profile())
+	assert_true(ctrl._fall_bracing, "brace engaged")
+
+	# Well past arm_fall_reach_duration (0.55 s ≈ 33 frames).
+	await wait_physics_frames(70)
+	assert_false(ctrl._fall_bracing, "brace releases after its window")


### PR DESCRIPTION
## What

Track B step 3 of 0.4.0 Self-Preservation: the upper-body **active** layer, so the whole hit reaction reads together — legs stumbling + arms windmilling for balance + reaching for the ground on a fall. User-validated in-editor over several tuning passes.

**Stacked on #91** (B2: `ArmIKSolver` + `TwoBoneIK`). Review/merge that first; base retargets to `main` after.

## Behaviors

- **Windmill (balance, during a stumble)** — each hand sweeps a wide vertical circle out to its own side, the two arms in opposite phase. The arc is coupled to the stumble's momentum (full at impact, winding down as the drift spends) and aligned to the fall direction, so it reads as a reaction to *this* hit, not a canned loop. Layered at partial weight over the loose flail — a tendency, not a takeover.
- **Reach-for-ground (protective fall break)** — when a hit commits to a fall, the leading arm reaches for the ground to break it. A brief braced window keeps that arm's springs alive and runs the IK **anchored to the physical arm** (a limp ragdoll has left its animation pose) while the rest goes limp, then releases into the full ragdoll on contact / window expiry. Gated to forward/side falls (a backward fall can't be broken by a hands-forward plant).

## Notable implementation

- **Override-channel coordination** — foot IK + arm IK now **merge** into a per-frame-cleared override set (foot first, arm last) via `SpringResolver.merge_target_overrides`, so both can write the same STAGGER frame without clobbering.
- **`ArmIKSolver` physics-anchored mode** — fixes the fall reach floating (it was solving from the animation pose while the body had fallen away).
- Tuning: new `RagdollTuning` "Self-Preservation: Arm Bracing" group; **Tuning Lab live sliders** for the stumble + arm knobs; **F3 debug HUD** draws the fall-reach target.

## Tests

GUT **136 → 141**: `test_fall_brace.gd` (forward braces leading arm / backward skips / min_facing configurable / releases) + physics-anchored & `get_reach` coverage in `test_arm_ik.gd`. The reach *motion* is validated visually; tests assert the state-machine wiring.

## Not final

Feel is good but we'll keep tuning later — all knobs are exposed in `RagdollTuning` + the Tuning Lab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)