### PR TITLE
release: 0.4.0 Self-Preservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-24
+
+**Self-Preservation** — the first *active* survival behaviors: a staggering hit now visibly
+shoves the character into a directed stumble (legs stepping to follow, lower body bracing
+upright, upper body reacting loose), and the arms actively brace — windmilling for balance
+during the stumble and reaching for the ground to break a committed fall. The springs are the
+muscles; this milestone is the first piece of the *brain* telling them what to do.
+
 ### Added
 - **Arm bracing** (0.4.0 Self-Preservation) — the upper-body active layer, so the whole
   reaction reads together. During a directed stumble the arms **windmill** for balance:

--- a/addons/kickback/plugin.cfg
+++ b/addons/kickback/plugin.cfg
@@ -3,5 +3,5 @@
 name="Kickback"
 description="Euphoria-like physics hit reactions for Godot 4.7+ — active ragdoll with stagger, full ragdoll, and recovery"
 author="Blugart"
-version="0.3.0"
+version="0.4.0"
 script="kickback_plugin.gd"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -29,7 +29,7 @@ figure is **~30%**.)
 | Version | Theme | Delivers |
 |---------|-------|----------|
 | **0.3.x** | Re-baseline + hardening | Honest docs & scorecard, plus the hardening batch: fixed silent multi-rig degradation, wired the budget manager (hard cap), added runtime smoke tests, generalized beyond Mixamo, and migrated `PhysicsRigSync` to a `SkeletonModifier3D`. See *Known hardening items* for what's resolved vs still open. |
-| **0.4.0** 🚧 | Self-Preservation | Directed stumble (shipped) + arm bracing (next) — the first *active* survival behaviors. **In progress** — see [SELF_PRESERVATION.md](SELF_PRESERVATION.md). |
+| **0.4.0** ✅ | Self-Preservation | Directed stumble + arm bracing (windmill for balance, reach-for-ground on a fall) — the first *active* survival behaviors. **Shipped** — see [SELF_PRESERVATION.md](SELF_PRESERVATION.md). |
 | **0.5.0** | Environmental Awareness | Wall/surface bracing + ground crawling. |
 | **0.6.0** | World Interaction | Environmental grabbing (IK reach + physics pins to grab points). |
 | **0.7.0** | Procedural Poses (core) | Replace canned recovery blends with target-seeking generated poses. |
@@ -65,5 +65,6 @@ the remainder is tracked here.
 
 **Still open:**
 
-- None currently tracked — the `0.3.x` hardening items are resolved. The next substantive
-  work is the `0.4.0` Self-Preservation layer (procedural stumble steps + arm bracing).
+- None currently tracked — the `0.3.x` hardening items are resolved and `0.4.0`
+  Self-Preservation (directed stumble + arm bracing) has shipped. The next substantive work
+  is the `0.5.0` Environmental Awareness layer (wall/surface bracing + ground crawling).


### PR DESCRIPTION
Cuts the **0.4.0 Self-Preservation** release.

- `plugin.cfg` 0.3.0 → **0.4.0**
- CHANGELOG `[Unreleased]` → **`[0.4.0]`** (2026-06-24)
- ROADMAP: 0.4.0 marked **shipped**; next up is 0.5.0 Environmental Awareness

Milestone content (merged via #91 + #92): directed stumble + arm bracing (windmill for balance, reach-for-ground on a committed fall) — the first *active* survival behaviors. GUT 141/141.

After merge: tag `v0.4.0` → `release.yml` auto-builds the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)